### PR TITLE
- Fixed NoClassDefFoundError: FinestWebview need guava

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -321,6 +321,9 @@ dependencies {
     // FinestWebView dependencies
     implementation 'com.nineoldandroids:library:2.4.0'
     implementation 'com.thefinestartist:utils:0.9.0'
+    implementation (group: 'com.google.guava', name: 'guava', version: '23.0-android') {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
 
     implementation 'com.stripe:stripe-android:10.3.1'
 


### PR DESCRIPTION
Issue: getlantern/engineering#575 

As our FinestWebview AAR was added manually, so we need to re-declare the dependencies in our app module. And during the process to reduce apk size, it appeared as unused then was removed as a result. I add it back under the FinestWebView dependencies section to make sure that we won't remove it again in future. 

Also, by adding back this one, the apk size will increase about 600kb. 