### PR TITLE
Always use getInt or getLong instead of prefs.getInt or prefs.getLong…

### DIFF
--- a/android/app/src/main/java/org/getlantern/lantern/model/LanternSessionManager.kt
+++ b/android/app/src/main/java/org/getlantern/lantern/model/LanternSessionManager.kt
@@ -154,7 +154,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     }
 
     fun getDeviceExp(): Long {
-        return prefs.getLong(DEVICE_CODE_EXP, 0)
+        return getLong(DEVICE_CODE_EXP, 0)
     }
 
     fun yinbiEnabled(): Boolean {
@@ -195,7 +195,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     }
 
     fun getExpiration(): LocalDateTime? {
-        val expiration = prefs.getLong(EXPIRY_DATE, 0L)
+        val expiration = getLong(EXPIRY_DATE, 0L)
         return if (expiration == 0L) {
             null
         } else LocalDateTime(expiration * 1000)
@@ -212,7 +212,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
 
         // Show only once to free users. (If set, don't show)
         // Also, if the install isn't new-ish, we won't start showing them a welcome.
-        return isRecentInstall && prefs.getLong(WELCOME_LAST_SEEN, 0) == 0L
+        return isRecentInstall && getLong(WELCOME_LAST_SEEN, 0) == 0L
     }
 
     fun numProMonths(): Int {

--- a/android/app/src/main/java/org/getlantern/mobilesdk/model/SessionManager.kt
+++ b/android/app/src/main/java/org/getlantern/mobilesdk/model/SessionManager.kt
@@ -123,7 +123,7 @@ abstract class SessionManager(application: Application) : Session {
     }
 
     fun hasAcceptedTerms(): Boolean {
-        return prefs.getInt(ACCEPTED_TERMS_VERSION, 0) >= CURRENT_TERMS_VERSION
+        return getInt(ACCEPTED_TERMS_VERSION, 0) >= CURRENT_TERMS_VERSION
     }
 
     fun acceptTerms() {
@@ -147,7 +147,7 @@ abstract class SessionManager(application: Application) : Session {
     }
 
     var showAdsAfterDays: Long
-        get() = prefs.getLong(SHOW_ADS_AFTER_DAYS, 0L)
+        get() = getLong(SHOW_ADS_AFTER_DAYS, 0L)
         set(days) {
             prefs.edit().putLong(SHOW_ADS_AFTER_DAYS, days).apply()
         }
@@ -363,7 +363,7 @@ abstract class SessionManager(application: Application) : Session {
         return try {
             prefs.getInt(name, defaultValue)
         } catch (e: ClassCastException) {
-            Logger.error(TAG, e.message)
+            Logger.debug(TAG, e.message)
             try {
                 prefs.getLong(name, defaultValue.toLong()).toInt()
             } catch (e2: ClassCastException) {
@@ -373,11 +373,11 @@ abstract class SessionManager(application: Application) : Session {
         }
     }
 
-    private fun getLong(name: String?, defaultValue: Long): Long {
+    protected fun getLong(name: String?, defaultValue: Long): Long {
         return try {
             prefs.getLong(name, defaultValue)
         } catch (e: ClassCastException) {
-            Logger.error(TAG, e.message)
+            Logger.debug(TAG, e.message)
             try {
                 prefs.getInt(name, defaultValue.toInt()).toLong()
             } catch (e2: ClassCastException) {
@@ -394,7 +394,7 @@ abstract class SessionManager(application: Application) : Session {
      * before, false is returned.
      */
     fun hasPrefExpired(name: String?): Boolean {
-        val expires = prefs.getLong(name, 0)
+        val expires = getLong(name, 0)
         return System.currentTimeMillis() >= expires
     }
 


### PR DESCRIPTION
…, closes getlantern/engineering#885

I tested this by first installing an old version of Lantern, upgrading to pro, then installing the new release and then verifying that it opens successfully and that the app recognizes me as pro.