### PR TITLE
Switch to latest version of audioplayers plugin which eliminates need…

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: audioplayers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.18.3"
+    version: "0.19.1"
   back_button_interceptor:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
 
   share: ^2.0.1
 
-  audioplayers: ^0.18.3
+  audioplayers: ^0.19.1
 
   stop_watch_timer: ^1.0.0
 


### PR DESCRIPTION
… for Android SDK 30

Closes getlantern/engineering#636.