### PR TITLE
Removed hexcolor plugin

### DIFF
--- a/lib/config/colors.dart
+++ b/lib/config/colors.dart
@@ -1,34 +1,35 @@
 import 'dart:ui';
 
-import 'package:hexcolor/hexcolor.dart';
+import 'package:flutter/material.dart';
 
-Color primaryBlue = HexColor('#007A7C');
-Color primaryPink = HexColor('#DB0A5B');
-Color primaryYellow = HexColor('#FFC107');
-Color secondaryBlue = HexColor('#00BCD4');
-Color secondaryPink = HexColor('#FF4081');
-Color secondaryYellow = HexColor('#FFE600');
-Color white = HexColor('#FFFFFF');
-Color black = HexColor('#000000');
-Color grey1 = HexColor('#F9F9F9');
-Color grey2 = HexColor('#F5F5F5');
-Color grey3 = HexColor('#EBEBEB');
-Color grey4 = HexColor('#BFBFBF');
-Color grey5 = HexColor('#707070');
-Color indicatorRed = HexColor('#D5001F');
-Color indicatorGreen = HexColor('#00A83E');
-Color overlayBlack = HexColor('#000000CB');
+Color primaryBlue = const Color.fromRGBO(0, 122, 124, 1);
+Color primaryPink = const Color.fromRGBO(219, 10, 90, 1);
+Color primaryYellow = const Color.fromRGBO(255, 193, 7, 1);
+Color secondaryBlue = const Color.fromRGBO(0, 188, 212, 1);
+Color secondaryPink = const Color.fromRGBO(255, 64, 128, 1);
+Color secondaryYellow = const Color.fromRGBO(255, 230, 0, 1);
+Color white = Colors.white;
+Color black = Colors.black;
+Color grey1 = const Color.fromRGBO(249, 249, 249, 1);
+Color grey2 = const Color.fromRGBO(245, 245, 245, 1);
+Color grey3 = const Color.fromRGBO(235, 235, 235, 1);
+Color grey4 = const Color.fromRGBO(191, 191, 191, 1);
+Color grey5 = const Color.fromRGBO(112, 112, 112, 1);
+Color overlayBlack = Colors.black87;
+Color borderColor = grey3;
 
-Color outboundBgColor = HexColor('#007A7C');
-Color outboundMsgColor = HexColor('#FFFFFF');
-Color inboundMsgColor = HexColor('#000000');
-Color inboundBgColor = HexColor('#EBEBEB');
+Color outboundBgColor = const Color.fromRGBO(0, 122, 124, 1);
+Color outboundMsgColor = white;
+Color inboundMsgColor = black;
+Color inboundBgColor = grey3;
+
+Color indicatorRed = const Color.fromRGBO(213, 0, 31, 1);
+Color indicatorGreen = secondaryBlue;
+Color offSwitchColor = grey5;
+Color onSwitchColor = secondaryBlue;
+Color usedDataBarColor = primaryBlue;
 
 Color unselectedTabColor = grey1;
 Color selectedTabColor = white;
 Color unselectedTabLabelColor = grey5;
 Color selectedTabLabelColor = black;
-Color borderColor = grey3;
-Color offSwitchColor = grey5;
-Color onSwitchColor = secondaryBlue;
-Color usedDataBarColor = primaryBlue;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -294,13 +294,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  hexcolor:
-    dependency: "direct main"
-    description:
-      name: hexcolor
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.4"
   http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,8 +78,6 @@ dependencies:
 
   email_validator: '^2.0.1'
 
-  hexcolor: ^2.0.4
-
   pin_code_text_field: ^1.8.0
 
   styled_text: ^3.0.1


### PR DESCRIPTION
Removed previous implementation of hexcolor parser.

Flutter already provide a clean approach for color selection, using the basic material color palette: ```Colors.myColor.opacity.r.g.b``` or we can use the RGB extension with: ```Color.fromRGBO(red, green, blue, opacity)```