### PR TITLE
Emoji picker fix

### DIFF
--- a/lib/messaging/conversation.dart
+++ b/lib/messaging/conversation.dart
@@ -374,12 +374,14 @@ class _ConversationState extends State<Conversation>
                     dismissKeyboard();
                     await model.react(_storedMessage!, emoji.emoji);
                     _storedMessage = null;
+                    setState(() => _emojiShowing = false);
+                  } else {
+                    setState(() => _isSendIconVisible = true);
+                    _newMessage
+                      ..text += emoji.emoji
+                      ..selection = TextSelection.fromPosition(
+                          TextPosition(offset: _newMessage.text.length));
                   }
-                  setState(() => _isSendIconVisible = true);
-                  _newMessage
-                    ..text += emoji.emoji
-                    ..selection = TextSelection.fromPosition(
-                        TextPosition(offset: _newMessage.text.length));
                 },
               ),
             ],


### PR DESCRIPTION
This is linked with the issue found by kalli, that when the user tap on the dots to reply with a custom emoji, the keyboard is displayed and the selected emoji is rendered in both the message bar and response

Closing getlantern/engineering#634 