### PR TITLE
Using new db-android that caches SharedPreferences values in memory

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -437,7 +437,7 @@ dependencies {
 
     implementation "com.github.YarikSOffice:lingver:1.3.0"
     implementation 'com.github.getlantern:secrets-android:3ac588e'
-    implementation 'com.github.getlantern:db-android:806f292832'
+    implementation 'com.github.getlantern:db-android:db23e4a298'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/android/app/src/main/java/org/getlantern/lantern/LanternApp.java
+++ b/android/app/src/main/java/org/getlantern/lantern/LanternApp.java
@@ -21,7 +21,6 @@ import com.squareup.leakcanary.LeakCanary;
 import org.getlantern.lantern.model.InAppBilling;
 import org.getlantern.lantern.model.LanternHttpClient;
 import org.getlantern.lantern.model.LanternSessionManager;
-import org.getlantern.lantern.model.ProPlan;
 import org.getlantern.lantern.model.Utils;
 import org.getlantern.lantern.model.VpnState;
 import org.getlantern.lantern.model.WelcomeDialog;

--- a/android/app/src/main/java/org/getlantern/lantern/model/LanternSessionManager.kt
+++ b/android/app/src/main/java/org/getlantern/lantern/model/LanternSessionManager.kt
@@ -25,11 +25,11 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     private var verifyCode: String? = null
 
     override fun isProUser(): Boolean {
-        return getBoolean(PRO_USER, false)
+        return prefs.getBoolean(PRO_USER, false)
     }
 
     fun isExpired(): Boolean {
-        return getBoolean(PRO_EXPIRED, false)
+        return prefs.getBoolean(PRO_EXPIRED, false)
     }
 
     fun getCurrency(): Currency? {
@@ -154,11 +154,11 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     }
 
     fun getDeviceExp(): Long {
-        return getLong(DEVICE_CODE_EXP, 0)
+        return prefs.getLong(DEVICE_CODE_EXP, 0)
     }
 
     fun yinbiEnabled(): Boolean {
-        return BuildConfig.YINBI_ENABLED || getBoolean(YINBI_ENABLED, false)
+        return BuildConfig.YINBI_ENABLED || prefs.getBoolean(YINBI_ENABLED, false)
     }
 
     fun setYinbiEnabled(enabled: Boolean) {
@@ -170,7 +170,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     }
 
     fun showYinbiRedemptionTable(): Boolean {
-        return getBoolean(SHOW_YINBI_REDEMPTION, false)
+        return prefs.getBoolean(SHOW_YINBI_REDEMPTION, false)
     }
 
     fun setShowRedemptionTable(v: Boolean) {
@@ -178,7 +178,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     }
 
     fun getProDaysLeft(): Int {
-        return getInt(PRO_DAYS_LEFT, 0)
+        return prefs.getInt(PRO_DAYS_LEFT, 0)
     }
 
     private fun setExpiration(expiration: Long?) {
@@ -195,7 +195,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     }
 
     fun getExpiration(): LocalDateTime? {
-        val expiration = getLong(EXPIRY_DATE, 0L)
+        val expiration = prefs.getLong(EXPIRY_DATE, 0L)
         return if (expiration == 0L) {
             null
         } else LocalDateTime(expiration * 1000)
@@ -212,11 +212,11 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
 
         // Show only once to free users. (If set, don't show)
         // Also, if the install isn't new-ish, we won't start showing them a welcome.
-        return isRecentInstall && getLong(WELCOME_LAST_SEEN, 0) == 0L
+        return isRecentInstall && prefs.getLong(WELCOME_LAST_SEEN, 0) == 0L
     }
 
     fun numProMonths(): Int {
-        return getInt(PRO_MONTHS_LEFT, 0)
+        return prefs.getInt(PRO_MONTHS_LEFT, 0)
     }
 
     fun setWelcomeLastSeen() {
@@ -229,7 +229,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     }
 
     fun showRenewalPref(): Boolean {
-        return getBoolean(SHOW_RENEWAL_PREF, true)
+        return prefs.getBoolean(SHOW_RENEWAL_PREF, true)
     }
 
     fun setProPlan(plan: ProPlan?) {
@@ -339,7 +339,7 @@ class LanternSessionManager(application: Application) : SessionManager(applicati
     // isPlayVersion checks whether or not the user installed Lantern via
     // the Google Play store
     override fun isPlayVersion(): Boolean {
-        if (BuildConfig.PLAY_VERSION || getBoolean(PLAY_VERSION, false)) {
+        if (BuildConfig.PLAY_VERSION || prefs.getBoolean(PLAY_VERSION, false)) {
             return true
         }
         try {

--- a/android/app/src/main/java/org/getlantern/mobilesdk/model/SessionManager.kt
+++ b/android/app/src/main/java/org/getlantern/mobilesdk/model/SessionManager.kt
@@ -124,7 +124,7 @@ abstract class SessionManager(application: Application) : Session {
     }
 
     fun hasAcceptedTerms(): Boolean {
-        return getInt(ACCEPTED_TERMS_VERSION, 0) >= CURRENT_TERMS_VERSION
+        return prefs.getInt(ACCEPTED_TERMS_VERSION, 0) >= CURRENT_TERMS_VERSION
     }
 
     fun acceptTerms() {
@@ -148,7 +148,7 @@ abstract class SessionManager(application: Application) : Session {
     }
 
     var showAdsAfterDays: Long
-        get() = getLong(SHOW_ADS_AFTER_DAYS, 0L)
+        get() = prefs.getLong(SHOW_ADS_AFTER_DAYS, 0L)
         set(days) {
             prefs.edit().putLong(SHOW_ADS_AFTER_DAYS, days).apply()
         }
@@ -191,7 +191,7 @@ abstract class SessionManager(application: Application) : Session {
     }
 
     override fun proxyAll(): Boolean {
-        return getBoolean(PROXY_ALL, false)
+        return prefs.getBoolean(PROXY_ALL, false)
     }
 
     fun setProxyAll(proxyAll: Boolean) {
@@ -265,7 +265,7 @@ abstract class SessionManager(application: Application) : Session {
             // production environment but that gets special treatment from the proserver to hit
             // payment providers' test endpoints.
             9007199254740992L
-        } else getLong(USER_ID, 0)
+        } else prefs.getLong(USER_ID, 0)
     }
 
     override fun getToken(): String {
@@ -276,7 +276,7 @@ abstract class SessionManager(application: Application) : Session {
     }
 
     private val isPaymentTestMode: Boolean
-        get() = getBoolean(PAYMENT_TEST_MODE, false)
+        get() = prefs.getBoolean(PAYMENT_TEST_MODE, false)
 
     fun setPaymentTestMode(mode: Boolean) {
         prefs.edit().putBoolean(PAYMENT_TEST_MODE, mode).apply()
@@ -322,7 +322,7 @@ abstract class SessionManager(application: Application) : Session {
     }
 
     fun surveyLinkOpened(url: String?): Boolean {
-        return getBoolean(url, false)
+        return prefs.getBoolean(url, false)
     }
 
     override fun setStaging(staging: Boolean) {
@@ -360,34 +360,6 @@ abstract class SessionManager(application: Application) : Session {
         )
     }
 
-    protected fun getInt(name: String?, defaultValue: Int): Int {
-        var value = db.get<Any>(name!!) ?: defaultValue
-        return when (value) {
-            is Number -> value.toInt()
-            is String -> value.toInt()
-            else -> throw ClassCastException("$value cannot be cast to Int")
-        }
-    }
-
-    protected fun getLong(name: String?, defaultValue: Long): Long {
-        var value = db.get<Any>(name!!) ?: defaultValue
-        return when (value) {
-            is Number -> value.toLong()
-            is String -> value.toLong()
-            else -> throw ClassCastException("$value cannot be cast to Long")
-        }
-    }
-
-    protected fun getBoolean(name: String?, defaultValue: Boolean): Boolean {
-        var value = db.get<Any>(name!!) ?: defaultValue
-        return when (value) {
-            is Boolean -> value
-            is Number -> value.toInt() == 1
-            is String -> value.toBoolean()
-            else -> throw ClassCastException("$value cannot be cast to Boolean")
-        }
-    }
-
     /**
      * hasPrefExpired checks whether or not a particular
      * shared preference has expired (assuming its stored value
@@ -395,7 +367,7 @@ abstract class SessionManager(application: Application) : Session {
      * before, false is returned.
      */
     fun hasPrefExpired(name: String?): Boolean {
-        val expires = getLong(name, 0)
+        val expires = prefs.getLong(name, 0)
         return System.currentTimeMillis() >= expires
     }
 
@@ -497,18 +469,18 @@ abstract class SessionManager(application: Application) : Session {
         context = application
         vpnModel = VpnModel()
         Logger.debug(TAG, "VpnModel() finished at ${System.currentTimeMillis() - start}")
+        db = BaseModel.masterDB.withSchema(PREFERENCES_SCHEMA)
+        db.registerType(2000, Vpn.Device::class.java)
+        db.registerType(2001, Vpn.Devices::class.java)
         val prefsAdapter = BaseModel.masterDB.asSharedPreferences(
             PREFERENCES_SCHEMA, context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
         )
         prefs = prefsAdapter
-        db = prefsAdapter.db
         prefs.edit().putBoolean(DEVELOPMENT_MODE, BuildConfig.DEVELOPMENT_MODE)
-            .putBoolean(PAYMENT_TEST_MODE, getBoolean(PAYMENT_TEST_MODE, false))
-            .putBoolean(PLAY_VERSION, getBoolean(PLAY_VERSION, false))
-            .putBoolean(YINBI_ENABLED, getBoolean(YINBI_ENABLED, false))
+            .putBoolean(PAYMENT_TEST_MODE, prefs.getBoolean(PAYMENT_TEST_MODE, false))
+            .putBoolean(PLAY_VERSION, prefs.getBoolean(PLAY_VERSION, false))
+            .putBoolean(YINBI_ENABLED, prefs.getBoolean(YINBI_ENABLED, false))
             .putString(FORCE_COUNTRY, prefs.getString(FORCE_COUNTRY, "")).apply()
-        db.registerType(2000, Vpn.Device::class.java)
-        db.registerType(2001, Vpn.Devices::class.java)
         Logger.debug(TAG, "prefs.edit() finished at ${System.currentTimeMillis() - start}")
         internalHeaders = context.getSharedPreferences(
             INTERNAL_HEADERS_PREF_NAME,


### PR DESCRIPTION
For getlantern/lantern-internal#4924

Depends on https://github.com/getlantern/db-android/pull/6

Instead of caching values for periods of time like #213, this relies on caching that's now native handled by db-android's implementation of SharedPreferences. All of the stuff that we're hammering is through the SharedPreferences API, so this takes care of things and even better, there's no latency for getting updated values since SharedPreferences keeps its cache fresh relative to what's in the database.

- [X] Do the tests pass? Consistently?