### PR TITLE
Reusing same db instance for SessionModel and SharedPreferences

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -417,7 +417,7 @@ dependencies {
 
     implementation "com.github.YarikSOffice:lingver:1.3.0"
     implementation 'com.github.getlantern:secrets-android:3ac588e'
-    implementation 'com.github.getlantern:db-android:db23e4a298'
+    implementation 'com.github.getlantern:db-android:4d13d81641'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/android/app/src/main/java/org/getlantern/mobilesdk/model/SessionManager.kt
+++ b/android/app/src/main/java/org/getlantern/mobilesdk/model/SessionManager.kt
@@ -470,8 +470,8 @@ abstract class SessionManager(application: Application) : Session {
         db = BaseModel.masterDB.withSchema(PREFERENCES_SCHEMA)
         db.registerType(2000, Vpn.Device::class.java)
         db.registerType(2001, Vpn.Devices::class.java)
-        val prefsAdapter = BaseModel.masterDB.asSharedPreferences(
-            PREFERENCES_SCHEMA, context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        val prefsAdapter = db.asSharedPreferences(
+            context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
         )
         prefs = prefsAdapter
         prefs.edit().putBoolean(DEVELOPMENT_MODE, BuildConfig.DEVELOPMENT_MODE)


### PR DESCRIPTION
For getlantern/engineering#639.

Depends on https://github.com/getlantern/db-android/pull/7

The reason that we weren't getting updates when the shared preferences changed is that we were subscribing to one DB (schema really) but the SharedPreferences were internally creating their own schema, so we were missing the updates.

With [this PR](https://github.com/getlantern/db-android/pull/7) we gain the ability to reuse a single DB/schema inside of the SharedPreferences, which allows our subscriptions to work.

I tested this manually and confirmed that the badge disappears after I view the Yinbi screen.

https://user-images.githubusercontent.com/5000654/127586590-3d10684b-ec80-47b8-bada-c682c7959d7d.mov

- [x] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [x] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [na] Have you logged tickets for related technical debt with the label “techdebt”?
