### PR TITLE
Crdzbird/audio duration

### DIFF
--- a/android/app/src/main/kotlin/io/lantern/android/model/MessagingModel.kt
+++ b/android/app/src/main/kotlin/io/lantern/android/model/MessagingModel.kt
@@ -84,7 +84,7 @@ class MessagingModel constructor(private val activity: MainActivity, flutterEngi
                     setDataSource(activity.applicationContext, uri)
                 }.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
                 val metadata = call.argument<Map<String, String>?>("metadata")?.toMutableMap()?.apply {
-                    put("duration", (duration.toLongOrNull() ?: 1000.0 / 1000.0).toString())
+                    put("duration", (duration.toDoubleOrNull() ?: 1000.0 / 1000.0).toString())
                 }
                 return messaging.createAttachment(file, "", metadata!!.toMap()).toByteArray()
             }


### PR DESCRIPTION
Added capability to retrieve the duration from any audio file, it should be in milli and following the same setup as `stopReocordingVoiceMemo`

Note: This is just for Kotlin to return the duration inside the metadata.