### PR TITLE
Move database to new location to avoid corruption on Android 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+<a name="6.8.3"></a>
+## [6.8.3](https://github.com/getlantern/android-lantern/compare/6.8.2...6.8.3)
+
+> 2021-08-17
+
+### Pull Requests
+
+* Merge pull request [#306](https://github.com/getlantern/android-lantern/issues/306) from getlantern/ox/issue304
+
+
 <a name="6.8.2"></a>
 ## [6.8.2](https://github.com/getlantern/android-lantern/compare/6.8.1...6.8.2)
 


### PR DESCRIPTION
I can't explain why this works, but it does.

1. Storing the database in a different location (not in the `.lantern` folder) prevents it from becoming corrupted
2. Taking a previous database that failed to open and moving it to the new location allows it to open successfully ?!

So there's something weird going on with storing the database in the `.lantern` folder. My best guess is that something else that uses that folder (like our native Go code) is messing with the files somehow.

I tested my solution by doing the following:

1. Run an old build on an Android 5.1 emulator with some test code that immediately crashes it
2. Run it again and see that Lantern fails to start with the "file is not a database" error
3. Upgrade to a new build with this fix
4. See that Lantern starts and that the log shows us migrating the old database files

- [x] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
