### PR TITLE
Modal display render error 'No Size'

### DIFF
--- a/lib/messaging/widgets/message_utils.dart
+++ b/lib/messaging/widgets/message_utils.dart
@@ -389,7 +389,6 @@ Future<void> displayConversationOptions(
                                 child: Scrollbar(
                                   controller: scrollController,
                                   interactive: true,
-                                  isAlwaysShown: true,
                                   showTrackOnHover: true,
                                   isAlwaysShown: true,
                                   radius: const Radius.circular(50),


### PR DESCRIPTION
On some devices, the `Disappearing Messages Modal` seems to have an issue where the constraints doesn't limit the height of the ListView.

![image](https://user-images.githubusercontent.com/7727498/132715269-0d40cb8a-5c1b-40a3-99f7-292646f6b072.png)