### PR TITLE
Upgraded to latest flutter_webrtc, closes getlantern/android-lantern#324

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -466,7 +466,7 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   fluttertoast:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -101,7 +101,7 @@ dependencies:
 
   file_picker: ^4.0.2
 
-  flutter_webrtc: ^0.6.5
+  flutter_webrtc: ^0.6.7
 
   flutter_ringtone_player: ^3.0.0
 


### PR DESCRIPTION
I tested this by making a call, hanging up, and then playing music on both phones using Youtube Music.

I called again just to make sure, and playing music still worked.