### PR TITLE
Upgraded to Flutter 2.5.3 to support display of HEIC images on device…

### DIFF
--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -19,7 +19,6 @@ export 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 export 'package:google_fonts/google_fonts.dart';
 export 'package:i18n_extension/i18n_widget.dart';
 export 'package:loader_overlay/loader_overlay.dart';
-export 'package:pedantic/pedantic.dart';
 export 'package:provider/provider.dart';
 export 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 export 'package:stop_watch_timer/stop_watch_timer.dart';

--- a/lib/common/ui/custom/text.dart
+++ b/lib/common/ui/custom/text.dart
@@ -231,7 +231,8 @@ class CTextStyle extends TextStyle {
       Color? decorationColor,
       TextDecorationStyle? decorationStyle,
       double? decorationThickness,
-      String? debugLabel}) {
+      String? debugLabel,
+      TextOverflow? overflow}) {
     assert(false, 'copyWith not supported, use copiedWith');
     return this;
   }

--- a/lib/core/router/router.gr.dart
+++ b/lib/core/router/router.gr.dart
@@ -4,288 +4,289 @@
 // AutoRouteGenerator
 // **************************************************************************
 
-import 'package:auto_route/auto_route.dart' as _i1;
-import 'package:flutter/material.dart' as _i2;
-import 'package:lantern/account/account_tab.dart' as _i11;
-import 'package:lantern/account/developer_settings.dart' as _i19;
-import 'package:lantern/account/device_linking/approve_device.dart' as _i18;
+import 'package:auto_route/auto_route.dart' as _i7;
+import 'package:flutter/material.dart' as _i19;
+import 'package:lantern/account/account_tab.dart' as _i10;
+import 'package:lantern/account/developer_settings.dart' as _i18;
+import 'package:lantern/account/device_linking/approve_device.dart' as _i17;
 import 'package:lantern/account/device_linking/authorize_device_for_pro.dart'
-    as _i15;
+    as _i14;
 import 'package:lantern/account/device_linking/authorize_device_via_email.dart'
-    as _i16;
+    as _i15;
 import 'package:lantern/account/device_linking/authorize_device_via_email_pin.dart'
-    as _i17;
-import 'package:lantern/account/language.dart' as _i14;
-import 'package:lantern/account/pro_account.dart' as _i12;
-import 'package:lantern/account/settings.dart' as _i13;
-import 'package:lantern/common/ui/full_screen_dialog.dart' as _i4;
-import 'package:lantern/home.dart' as _i3;
-import 'package:lantern/messaging/contacts/new_message.dart' as _i6;
-import 'package:lantern/messaging/conversation/conversation.dart' as _i5;
-import 'package:lantern/messaging/introductions/introduce.dart' as _i7;
-import 'package:lantern/messaging/introductions/introductions.dart' as _i8;
-import 'package:lantern/messaging/messages.dart' as _i9;
-import 'package:lantern/messaging/messaging.dart' as _i20;
-import 'package:lantern/vpn/vpn_tab.dart' as _i10;
+    as _i16;
+import 'package:lantern/account/language.dart' as _i13;
+import 'package:lantern/account/pro_account.dart' as _i11;
+import 'package:lantern/account/settings.dart' as _i12;
+import 'package:lantern/common/common.dart' as _i20;
+import 'package:lantern/common/ui/full_screen_dialog.dart' as _i2;
+import 'package:lantern/home.dart' as _i1;
+import 'package:lantern/messaging/contacts/new_message.dart' as _i4;
+import 'package:lantern/messaging/conversation/conversation.dart' as _i3;
+import 'package:lantern/messaging/introductions/introduce.dart' as _i5;
+import 'package:lantern/messaging/introductions/introductions.dart' as _i6;
+import 'package:lantern/messaging/messages.dart' as _i8;
+import 'package:lantern/messaging/messaging.dart' as _i21;
+import 'package:lantern/vpn/vpn_tab.dart' as _i9;
 
-class AppRouter extends _i1.RootStackRouter {
-  AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])
+class AppRouter extends _i7.RootStackRouter {
+  AppRouter([_i19.GlobalKey<_i19.NavigatorState>? navigatorKey])
       : super(navigatorKey);
 
   @override
-  final Map<String, _i1.PageFactory> pagesMap = {
-    Home.name: (routeData) => _i1.AdaptivePage<dynamic>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<HomeArgs>(orElse: () => const HomeArgs());
-          return _i3.HomePage(key: args.key);
-        }),
-    FullScreenDialogPage.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<FullScreenDialogPageArgs>();
-          return _i4.FullScreenDialog(widget: args.widget, key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    Conversation.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<ConversationArgs>();
-          return _i5.Conversation(
+  final Map<String, _i7.PageFactory> pagesMap = {
+    Home.name: (routeData) {
+      final args = routeData.argsAs<HomeArgs>(orElse: () => const HomeArgs());
+      return _i7.AdaptivePage<dynamic>(
+          routeData: routeData, child: _i1.HomePage(key: args.key));
+    },
+    FullScreenDialogPage.name: (routeData) {
+      final args = routeData.argsAs<FullScreenDialogPageArgs>();
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i2.FullScreenDialog(widget: args.widget, key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    Conversation.name: (routeData) {
+      final args = routeData.argsAs<ConversationArgs>();
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i3.Conversation(
               contactId: args.contactId,
-              initialScrollIndex: args.initialScrollIndex);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    NewMessage.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return _i6.NewMessage();
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    Introduce.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return _i7.Introduce();
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    Introductions.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return _i8.Introductions();
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    MessagesRouter.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return const _i1.EmptyRouterPage();
-        },
-        opaque: true,
-        barrierDismissible: false),
-    VpnRouter.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return const _i1.EmptyRouterPage();
-        },
-        opaque: true,
-        barrierDismissible: false),
-    AccountRouter.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return const _i1.EmptyRouterPage();
-        },
-        opaque: true,
-        barrierDismissible: false),
-    DeveloperRoute.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return const _i1.EmptyRouterPage();
-        },
-        opaque: true,
-        barrierDismissible: false),
-    MessagesRoute.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return _i9.Messages();
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    Vpn.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<VpnArgs>(orElse: () => const VpnArgs());
-          return _i10.VPNTab(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    Account.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (_) {
-          return _i11.AccountTab();
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    ProAccount.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args =
-              data.argsAs<ProAccountArgs>(orElse: () => const ProAccountArgs());
-          return _i12.ProAccount(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    Settings.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args =
-              data.argsAs<SettingsArgs>(orElse: () => const SettingsArgs());
-          return _i13.Settings(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    Language.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args =
-              data.argsAs<LanguageArgs>(orElse: () => const LanguageArgs());
-          return _i14.Language(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    AuthorizePro.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<AuthorizeProArgs>(
-              orElse: () => const AuthorizeProArgs());
-          return _i15.AuthorizeDeviceForPro(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    AuthorizeDeviceEmail.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<AuthorizeDeviceEmailArgs>(
-              orElse: () => const AuthorizeDeviceEmailArgs());
-          return _i16.AuthorizeDeviceViaEmail(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    AuthorizeDeviceEmailPin.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<AuthorizeDeviceEmailPinArgs>(
-              orElse: () => const AuthorizeDeviceEmailPinArgs());
-          return _i17.AuthorizeDeviceViaEmailPin(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    ApproveDevice.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<ApproveDeviceArgs>(
-              orElse: () => const ApproveDeviceArgs());
-          return _i18.ApproveDevice(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false),
-    DeveloperSettings.name: (routeData) => _i1.CustomPage<void>(
-        routeData: routeData,
-        builder: (data) {
-          final args = data.argsAs<DeveloperSettingsArgs>(
-              orElse: () => const DeveloperSettingsArgs());
-          return _i19.DeveloperSettingsTab(key: args.key);
-        },
-        transitionsBuilder: _i1.TransitionsBuilders.fadeIn,
-        durationInMilliseconds: 200,
-        reverseDurationInMilliseconds: 200,
-        opaque: true,
-        barrierDismissible: false)
+              initialScrollIndex: args.initialScrollIndex),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    NewMessage.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i4.NewMessage(),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    Introduce.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i5.Introduce(),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    Introductions.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i6.Introductions(),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    MessagesRouter.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: const _i7.EmptyRouterPage(),
+          opaque: true,
+          barrierDismissible: false);
+    },
+    VpnRouter.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: const _i7.EmptyRouterPage(),
+          opaque: true,
+          barrierDismissible: false);
+    },
+    AccountRouter.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: const _i7.EmptyRouterPage(),
+          opaque: true,
+          barrierDismissible: false);
+    },
+    DeveloperRoute.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: const _i7.EmptyRouterPage(),
+          opaque: true,
+          barrierDismissible: false);
+    },
+    MessagesRoute.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i8.Messages(),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    Vpn.name: (routeData) {
+      final args = routeData.argsAs<VpnArgs>(orElse: () => const VpnArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i9.VPNTab(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    Account.name: (routeData) {
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i10.AccountTab(),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    ProAccount.name: (routeData) {
+      final args = routeData.argsAs<ProAccountArgs>(
+          orElse: () => const ProAccountArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i11.ProAccount(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    Settings.name: (routeData) {
+      final args =
+          routeData.argsAs<SettingsArgs>(orElse: () => const SettingsArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i12.Settings(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    Language.name: (routeData) {
+      final args =
+          routeData.argsAs<LanguageArgs>(orElse: () => const LanguageArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i13.Language(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    AuthorizePro.name: (routeData) {
+      final args = routeData.argsAs<AuthorizeProArgs>(
+          orElse: () => const AuthorizeProArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i14.AuthorizeDeviceForPro(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    AuthorizeDeviceEmail.name: (routeData) {
+      final args = routeData.argsAs<AuthorizeDeviceEmailArgs>(
+          orElse: () => const AuthorizeDeviceEmailArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i15.AuthorizeDeviceViaEmail(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    AuthorizeDeviceEmailPin.name: (routeData) {
+      final args = routeData.argsAs<AuthorizeDeviceEmailPinArgs>(
+          orElse: () => const AuthorizeDeviceEmailPinArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i16.AuthorizeDeviceViaEmailPin(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    ApproveDevice.name: (routeData) {
+      final args = routeData.argsAs<ApproveDeviceArgs>(
+          orElse: () => const ApproveDeviceArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i17.ApproveDevice(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    },
+    DeveloperSettings.name: (routeData) {
+      final args = routeData.argsAs<DeveloperSettingsArgs>(
+          orElse: () => const DeveloperSettingsArgs());
+      return _i7.CustomPage<void>(
+          routeData: routeData,
+          child: _i18.DeveloperSettingsTab(key: args.key),
+          transitionsBuilder: _i7.TransitionsBuilders.fadeIn,
+          durationInMilliseconds: 200,
+          reverseDurationInMilliseconds: 200,
+          opaque: true,
+          barrierDismissible: false);
+    }
   };
 
   @override
-  List<_i1.RouteConfig> get routes => [
-        _i1.RouteConfig(Home.name, path: '/', children: [
-          _i1.RouteConfig(MessagesRouter.name,
+  List<_i7.RouteConfig> get routes => [
+        _i7.RouteConfig(Home.name, path: '/', children: [
+          _i7.RouteConfig(MessagesRouter.name,
               path: 'messages',
-              children: [_i1.RouteConfig(MessagesRoute.name, path: '')]),
-          _i1.RouteConfig(VpnRouter.name,
-              path: 'vpn', children: [_i1.RouteConfig(Vpn.name, path: '')]),
-          _i1.RouteConfig(AccountRouter.name, path: 'account', children: [
-            _i1.RouteConfig(Account.name, path: ''),
-            _i1.RouteConfig(ProAccount.name, path: 'proAccount'),
-            _i1.RouteConfig(Settings.name, path: 'settings'),
-            _i1.RouteConfig(Language.name, path: 'language'),
-            _i1.RouteConfig(AuthorizePro.name, path: 'authorizePro'),
-            _i1.RouteConfig(AuthorizeDeviceEmail.name,
+              children: [_i7.RouteConfig(MessagesRoute.name, path: '')]),
+          _i7.RouteConfig(VpnRouter.name,
+              path: 'vpn', children: [_i7.RouteConfig(Vpn.name, path: '')]),
+          _i7.RouteConfig(AccountRouter.name, path: 'account', children: [
+            _i7.RouteConfig(Account.name, path: ''),
+            _i7.RouteConfig(ProAccount.name, path: 'proAccount'),
+            _i7.RouteConfig(Settings.name, path: 'settings'),
+            _i7.RouteConfig(Language.name, path: 'language'),
+            _i7.RouteConfig(AuthorizePro.name, path: 'authorizePro'),
+            _i7.RouteConfig(AuthorizeDeviceEmail.name,
                 path: 'authorizeDeviceEmail'),
-            _i1.RouteConfig(AuthorizeDeviceEmailPin.name,
+            _i7.RouteConfig(AuthorizeDeviceEmailPin.name,
                 path: 'authorizeDeviceEmailPin'),
-            _i1.RouteConfig(ApproveDevice.name, path: 'approveDevice')
+            _i7.RouteConfig(ApproveDevice.name, path: 'approveDevice')
           ]),
-          _i1.RouteConfig(DeveloperRoute.name,
+          _i7.RouteConfig(DeveloperRoute.name,
               path: 'developer',
-              children: [_i1.RouteConfig(DeveloperSettings.name, path: '')])
+              children: [_i7.RouteConfig(DeveloperSettings.name, path: '')])
         ]),
-        _i1.RouteConfig(FullScreenDialogPage.name,
+        _i7.RouteConfig(FullScreenDialogPage.name,
             path: 'fullScreenDialogPage'),
-        _i1.RouteConfig(Conversation.name, path: 'conversation'),
-        _i1.RouteConfig(NewMessage.name, path: 'newMessage'),
-        _i1.RouteConfig(Introduce.name, path: 'introduce'),
-        _i1.RouteConfig(Introductions.name, path: 'introductions')
+        _i7.RouteConfig(Conversation.name, path: 'conversation'),
+        _i7.RouteConfig(NewMessage.name, path: 'newMessage'),
+        _i7.RouteConfig(Introduce.name, path: 'introduce'),
+        _i7.RouteConfig(Introductions.name, path: 'introductions')
       ];
 }
 
-class Home extends _i1.PageRouteInfo<HomeArgs> {
-  Home({_i20.Key? key, List<_i1.PageRouteInfo>? children})
+/// generated route for [_i1.HomePage]
+class Home extends _i7.PageRouteInfo<HomeArgs> {
+  Home({_i20.Key? key, List<_i7.PageRouteInfo>? children})
       : super(name,
             path: '/', args: HomeArgs(key: key), initialChildren: children);
 
@@ -298,7 +299,8 @@ class HomeArgs {
   final _i20.Key? key;
 }
 
-class FullScreenDialogPage extends _i1.PageRouteInfo<FullScreenDialogPageArgs> {
+/// generated route for [_i2.FullScreenDialog]
+class FullScreenDialogPage extends _i7.PageRouteInfo<FullScreenDialogPageArgs> {
   FullScreenDialogPage({required _i20.Widget widget, _i20.Key? key})
       : super(name,
             path: 'fullScreenDialogPage',
@@ -315,8 +317,9 @@ class FullScreenDialogPageArgs {
   final _i20.Key? key;
 }
 
-class Conversation extends _i1.PageRouteInfo<ConversationArgs> {
-  Conversation({required _i20.ContactId contactId, int? initialScrollIndex})
+/// generated route for [_i3.Conversation]
+class Conversation extends _i7.PageRouteInfo<ConversationArgs> {
+  Conversation({required _i21.ContactId contactId, int? initialScrollIndex})
       : super(name,
             path: 'conversation',
             args: ConversationArgs(
@@ -328,64 +331,73 @@ class Conversation extends _i1.PageRouteInfo<ConversationArgs> {
 class ConversationArgs {
   const ConversationArgs({required this.contactId, this.initialScrollIndex});
 
-  final _i20.ContactId contactId;
+  final _i21.ContactId contactId;
 
   final int? initialScrollIndex;
 }
 
-class NewMessage extends _i1.PageRouteInfo {
+/// generated route for [_i4.NewMessage]
+class NewMessage extends _i7.PageRouteInfo<void> {
   const NewMessage() : super(name, path: 'newMessage');
 
   static const String name = 'NewMessage';
 }
 
-class Introduce extends _i1.PageRouteInfo {
+/// generated route for [_i5.Introduce]
+class Introduce extends _i7.PageRouteInfo<void> {
   const Introduce() : super(name, path: 'introduce');
 
   static const String name = 'Introduce';
 }
 
-class Introductions extends _i1.PageRouteInfo {
+/// generated route for [_i6.Introductions]
+class Introductions extends _i7.PageRouteInfo<void> {
   const Introductions() : super(name, path: 'introductions');
 
   static const String name = 'Introductions';
 }
 
-class MessagesRouter extends _i1.PageRouteInfo {
-  const MessagesRouter({List<_i1.PageRouteInfo>? children})
+/// generated route for [_i7.EmptyRouterPage]
+class MessagesRouter extends _i7.PageRouteInfo<void> {
+  const MessagesRouter({List<_i7.PageRouteInfo>? children})
       : super(name, path: 'messages', initialChildren: children);
 
   static const String name = 'MessagesRouter';
 }
 
-class VpnRouter extends _i1.PageRouteInfo {
-  const VpnRouter({List<_i1.PageRouteInfo>? children})
+/// generated route for [_i7.EmptyRouterPage]
+class VpnRouter extends _i7.PageRouteInfo<void> {
+  const VpnRouter({List<_i7.PageRouteInfo>? children})
       : super(name, path: 'vpn', initialChildren: children);
 
   static const String name = 'VpnRouter';
 }
 
-class AccountRouter extends _i1.PageRouteInfo {
-  const AccountRouter({List<_i1.PageRouteInfo>? children})
+/// generated route for [_i7.EmptyRouterPage]
+class AccountRouter extends _i7.PageRouteInfo<void> {
+  const AccountRouter({List<_i7.PageRouteInfo>? children})
       : super(name, path: 'account', initialChildren: children);
 
   static const String name = 'AccountRouter';
 }
 
-class DeveloperRoute extends _i1.PageRouteInfo {
-  const DeveloperRoute({List<_i1.PageRouteInfo>? children})
+/// generated route for [_i7.EmptyRouterPage]
+class DeveloperRoute extends _i7.PageRouteInfo<void> {
+  const DeveloperRoute({List<_i7.PageRouteInfo>? children})
       : super(name, path: 'developer', initialChildren: children);
 
   static const String name = 'DeveloperRoute';
 }
 
-class MessagesRoute extends _i1.PageRouteInfo {
+/// generated route for [_i8.Messages]
+class MessagesRoute extends _i7.PageRouteInfo<void> {
   const MessagesRoute() : super(name, path: '');
 
   static const String name = 'MessagesRoute';
 }
 
-class Vpn extends _i1.PageRouteInfo<VpnArgs> {
+/// generated route for [_i9.VPNTab]
+class Vpn extends _i7.PageRouteInfo<VpnArgs> {
   Vpn({_i20.Key? key}) : super(name, path: '', args: VpnArgs(key: key));
 
   static const String name = 'Vpn';
@@ -397,13 +409,15 @@ class VpnArgs {
   final _i20.Key? key;
 }
 
-class Account extends _i1.PageRouteInfo {
+/// generated route for [_i10.AccountTab]
+class Account extends _i7.PageRouteInfo<void> {
   const Account() : super(name, path: '');
 
   static const String name = 'Account';
 }
 
-class ProAccount extends _i1.PageRouteInfo<ProAccountArgs> {
+/// generated route for [_i11.ProAccount]
+class ProAccount extends _i7.PageRouteInfo<ProAccountArgs> {
   ProAccount({_i20.Key? key})
       : super(name, path: 'proAccount', args: ProAccountArgs(key: key));
 
@@ -416,7 +430,8 @@ class ProAccountArgs {
   final _i20.Key? key;
 }
 
-class Settings extends _i1.PageRouteInfo<SettingsArgs> {
+/// generated route for [_i12.Settings]
+class Settings extends _i7.PageRouteInfo<SettingsArgs> {
   Settings({_i20.Key? key})
       : super(name, path: 'settings', args: SettingsArgs(key: key));
 
@@ -429,7 +444,8 @@ class SettingsArgs {
   final _i20.Key? key;
 }
 
-class Language extends _i1.PageRouteInfo<LanguageArgs> {
+/// generated route for [_i13.Language]
+class Language extends _i7.PageRouteInfo<LanguageArgs> {
   Language({_i20.Key? key})
       : super(name, path: 'language', args: LanguageArgs(key: key));
 
@@ -442,7 +458,8 @@ class LanguageArgs {
   final _i20.Key? key;
 }
 
-class AuthorizePro extends _i1.PageRouteInfo<AuthorizeProArgs> {
+/// generated route for [_i14.AuthorizeDeviceForPro]
+class AuthorizePro extends _i7.PageRouteInfo<AuthorizeProArgs> {
   AuthorizePro({_i20.Key? key})
       : super(name, path: 'authorizePro', args: AuthorizeProArgs(key: key));
 
@@ -455,7 +472,8 @@ class AuthorizeProArgs {
   final _i20.Key? key;
 }
 
-class AuthorizeDeviceEmail extends _i1.PageRouteInfo<AuthorizeDeviceEmailArgs> {
+/// generated route for [_i15.AuthorizeDeviceViaEmail]
+class AuthorizeDeviceEmail extends _i7.PageRouteInfo<AuthorizeDeviceEmailArgs> {
   AuthorizeDeviceEmail({_i20.Key? key})
       : super(name,
             path: 'authorizeDeviceEmail',
@@ -470,8 +488,9 @@ class AuthorizeDeviceEmailArgs {
   final _i20.Key? key;
 }
 
+/// generated route for [_i16.AuthorizeDeviceViaEmailPin]
 class AuthorizeDeviceEmailPin
-    extends _i1.PageRouteInfo<AuthorizeDeviceEmailPinArgs> {
+    extends _i7.PageRouteInfo<AuthorizeDeviceEmailPinArgs> {
   AuthorizeDeviceEmailPin({_i20.Key? key})
       : super(name,
             path: 'authorizeDeviceEmailPin',
@@ -486,7 +505,8 @@ class AuthorizeDeviceEmailPinArgs {
   final _i20.Key? key;
 }
 
-class ApproveDevice extends _i1.PageRouteInfo<ApproveDeviceArgs> {
+/// generated route for [_i17.ApproveDevice]
+class ApproveDevice extends _i7.PageRouteInfo<ApproveDeviceArgs> {
   ApproveDevice({_i20.Key? key})
       : super(name, path: 'approveDevice', args: ApproveDeviceArgs(key: key));
 
@@ -499,7 +519,8 @@ class ApproveDeviceArgs {
   final _i20.Key? key;
 }
 
-class DeveloperSettings extends _i1.PageRouteInfo<DeveloperSettingsArgs> {
+/// generated route for [_i18.DeveloperSettingsTab]
+class DeveloperSettings extends _i7.PageRouteInfo<DeveloperSettingsArgs> {
   DeveloperSettings({_i20.Key? key})
       : super(name, path: '', args: DeveloperSettingsArgs(key: key));
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "22.0.0"
+    version: "30.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "2.7.0"
   archive:
     dependency: transitive
     description:
@@ -28,14 +28,14 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   audioplayers:
     dependency: "direct main"
     description:
@@ -49,21 +49,21 @@ packages:
       name: auto_route
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.2"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.4.1"
   back_button_interceptor:
     dependency: "direct main"
     description:
       name: back_button_interceptor
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   badges:
     dependency: "direct main"
     description:
@@ -91,7 +91,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build_config:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   build_resolvers:
     dependency: transitive
     description:
@@ -119,21 +119,21 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.2"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "5.1.1"
   built_value:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -218,20 +218,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.2.0"
   device_info_plus:
     dependency: transitive
     description:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   device_info_plus_linux:
     dependency: transitive
     description:
@@ -245,14 +252,14 @@ packages:
       name: device_info_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   device_info_plus_web:
     dependency: transitive
     description:
@@ -273,7 +280,7 @@ packages:
       name: dio
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   dotted_border:
     dependency: "direct main"
     description:
@@ -294,7 +301,7 @@ packages:
       name: emoji_picker_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.7"
   equatable:
     dependency: transitive
     description:
@@ -308,7 +315,7 @@ packages:
       name: extended_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.1"
   extended_image_library:
     dependency: transitive
     description:
@@ -336,14 +343,14 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   file_picker:
     dependency: "direct main"
     description:
       name: file_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.6"
   fixnum:
     dependency: transitive
     description:
@@ -374,7 +381,7 @@ packages:
       name: flutter_keyboard_visibility
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.3"
+    version: "5.1.0"
   flutter_keyboard_visibility_platform_interface:
     dependency: transitive
     description:
@@ -395,7 +402,7 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.1+1"
+    version: "8.2.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
@@ -421,21 +428,21 @@ packages:
       name: flutter_markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.8"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.4"
   flutter_ringtone_player:
     dependency: "direct main"
     description:
       name: flutter_ringtone_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -466,7 +473,7 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.10+hotfix.1"
   fluttertoast:
     dependency: "direct main"
     description:
@@ -499,7 +506,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   google_fonts:
     dependency: "direct main"
     description:
@@ -513,7 +520,7 @@ packages:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   hexcolor:
     dependency: "direct main"
     description:
@@ -521,13 +528,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   http:
     dependency: transitive
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.4"
   http_client_helper:
     dependency: transitive
     description:
@@ -555,7 +569,7 @@ packages:
       name: i18n_extension
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
+    version: "4.1.3"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -588,7 +602,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.3.0"
   loader_overlay:
     dependency: "direct main"
     description:
@@ -602,7 +616,7 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   mailer:
     dependency: transitive
     description:
@@ -630,21 +644,21 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.15"
+    version: "5.0.16"
   nested:
     dependency: transitive
     description:
@@ -665,14 +679,14 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   package_info_plus:
     dependency: transitive
     description:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.3.0"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -686,7 +700,7 @@ packages:
       name: package_info_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -707,7 +721,7 @@ packages:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   path:
     dependency: transitive
     description:
@@ -721,7 +735,7 @@ packages:
       name: path_drawing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.1+1"
   path_parsing:
     dependency: transitive
     description:
@@ -735,14 +749,14 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.5"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   path_provider_macos:
     dependency: transitive
     description:
@@ -777,7 +791,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.4.0"
   pin_code_text_field:
     dependency: "direct main"
     description:
@@ -798,7 +812,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   pool:
     dependency: transitive
     description:
@@ -812,7 +826,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "4.2.3"
   protobuf:
     dependency: "direct main"
     description:
@@ -833,14 +847,14 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   qr:
     dependency: transitive
     description:
@@ -868,14 +882,14 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.1"
+    version: "0.27.2"
   scrollable_positioned_list:
     dependency: "direct main"
     description:
       name: scrollable_positioned_list
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0-nullsafety.0"
+    version: "0.2.2"
   sentry:
     dependency: "direct main"
     description:
@@ -896,7 +910,7 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -971,7 +985,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1041,7 +1055,7 @@ packages:
       name: styled_text
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.4"
   sync_http:
     dependency: transitive
     description:
@@ -1062,28 +1076,28 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.8"
+    version: "1.17.10"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.4.0"
   timezone:
     dependency: transitive
     description:
       name: timezone
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.0"
   timing:
     dependency: transitive
     description:
@@ -1111,21 +1125,21 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.9"
+    version: "6.0.12"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1153,7 +1167,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.0.5"
   vector_math:
     dependency: transitive
     description:
@@ -1167,35 +1181,35 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.14"
+    version: "2.2.5"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.0"
+    version: "7.1.1"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1223,7 +1237,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.7"
+    version: "2.2.10"
   xdg_directories:
     dependency: transitive
     description:
@@ -1237,7 +1251,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.2"
+    version: "5.3.1"
   xmlstream:
     dependency: transitive
     description:
@@ -1253,5 +1267,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
-  flutter: ">=2.2.0"
+  dart: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"


### PR DESCRIPTION
For getlantern/lantern#451.

Upgrading to the latest Flutter adds support for HEIC on devices that support it.

- [x] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [x] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [x] All text styles are defined in `text_styles.dart` and are not duplicated
- [x] All icons are using the vector resource from Figma (do not use built-in Icons)
- [x] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [x] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
