### PR TITLE
Lazily initialize messaging system after someone starts onboarding

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -419,7 +419,7 @@ dependencies {
     // from https://github.com/getlantern/opus_android
     implementation(name:'opuslib-release', ext: 'aar')
     implementation 'com.github.getlantern:secrets-android:f6a7a69f3d'
-    implementation 'com.github.getlantern:messaging-android:d402131337'
+    implementation 'com.github.getlantern:messaging-android:6583a710d1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/android/app/src/main/kotlin/io/lantern/android/model/MessagingModel.kt
+++ b/android/app/src/main/kotlin/io/lantern/android/model/MessagingModel.kt
@@ -23,7 +23,11 @@ import java.io.File
 import java.io.FileInputStream
 import java.util.concurrent.atomic.AtomicReference
 
-class MessagingModel constructor(private val activity: MainActivity, flutterEngine: FlutterEngine, private val messaging: Messaging) : BaseModel("messaging", flutterEngine, messaging.db) {
+class MessagingModel constructor(
+    private val activity: MainActivity,
+    flutterEngine: FlutterEngine,
+    private val messaging: Messaging
+) : BaseModel("messaging", flutterEngine, messaging.db) {
     private val voiceMemoFile = File(activity.cacheDir, "_voicememo.opus") // TODO: would be nice not to record the unencrypted voice memo to disk
     private val videoFile = File(activity.cacheDir, "_playingvideo") // TODO: would be nice to expose this via a MediaDataSource instead
     private val stopRecording = AtomicReference<Runnable>()
@@ -96,6 +100,12 @@ class MessagingModel constructor(private val activity: MainActivity, flutterEngi
 
     override fun doMethodCall(call: MethodCall, notImplemented: () -> Unit): Any? {
         return when (call.method) {
+            /*
+             * Lifecycle
+             */
+            "start" -> messaging.start()
+            "kill" -> messaging.kill()
+
             /*
             * Contacts
             */

--- a/lib/messaging/messaging_model.dart
+++ b/lib/messaging/messaging_model.dart
@@ -30,6 +30,16 @@ class MessagingModel extends Model {
       }
     });
   }
+  /*
+   * Lifecycle
+   */
+  Future<void> start() {
+    return methodChannel.invokeMethod('start');
+  }
+
+  Future<void> kill() {
+    return methodChannel.invokeMethod('kill');
+  }
 
   /*
   * CONTACTS 

--- a/lib/messaging/onboarding/welcome.dart
+++ b/lib/messaging/onboarding/welcome.dart
@@ -3,14 +3,18 @@ import '../messaging.dart';
 class Welcome extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final model = context.watch<MessagingModel>();
+
     return BaseScreen(
       title: 'lantern_secure_chat'.i18n,
       automaticallyImplyLeading: false,
-      body: PinnedButtonLayout(
-        content: [
-          const Padding(
-            padding: EdgeInsetsDirectional.only(top: 16.0),
-            child: CAssetImage(path: ImagePaths.placeholder, size: 300),
+      body: Column(
+        children: [
+          const Expanded(
+            child: Padding(
+              padding: EdgeInsetsDirectional.only(top: 16.0),
+              child: CAssetImage(path: ImagePaths.placeholder, size: 300),
+            ),
           ),
           Padding(
             padding: const EdgeInsetsDirectional.only(top: 16.0, bottom: 16.0),
@@ -19,34 +23,31 @@ class Welcome extends StatelessWidget {
           Padding(
             padding: const EdgeInsetsDirectional.only(top: 16.0, bottom: 16.0),
             child: CText('welcome_text'.i18n, style: tsBody1),
-          )
-        ],
-        button: Column(
-          children: [
-            Button(
+          ),
+          Button(
               text: 'get_started'.i18n,
               width: 200.0,
-              onPressed: () =>
-                  context.router.push(const SecureChatNumberMessaging()),
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(end: 8.0),
-                  child: CText('want_to_recover'.i18n.toUpperCase(),
-                      style: tsBody2),
-                ),
-                TextButton(
-                    onPressed: () =>
-                        context.router.push(const SecureNumberRecovery()),
-                    child: CText('recover'.i18n.toUpperCase(),
-                        style: tsBody2.copiedWith(
-                            color: pink4, fontWeight: FontWeight.w500)))
-              ],
-            ),
-          ],
-        ),
+              onPressed: () async {
+                await model.start();
+                await context.router.push(const SecureChatNumberMessaging());
+              }),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Padding(
+                padding: const EdgeInsetsDirectional.only(end: 8.0),
+                child:
+                    CText('want_to_recover'.i18n.toUpperCase(), style: tsBody2),
+              ),
+              TextButton(
+                  onPressed: () =>
+                      context.router.push(const SecureNumberRecovery()),
+                  child: CText('recover'.i18n.toUpperCase(),
+                      style: tsBody2.copiedWith(
+                          color: pink4, fontWeight: FontWeight.w500)))
+            ],
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
This does two things:

1. Uses a new version of messaging-android that delays initialization until called with `start()`. Calls `start()` at onboarding time.

2. Updates the layout of the welcome screen to auto-scale the hero image to allow everything to fit on screen

![image](https://user-images.githubusercontent.com/5000654/141588458-9ccff20d-17d5-4be4-ad00-9547437330ba.png)
