### PR TITLE
Force whole chats list to update anytime a single contact updates so …

### DIFF
--- a/lib/messaging/chats.dart
+++ b/lib/messaging/chats.dart
@@ -158,44 +158,41 @@ class _ChatsState extends State<Chats> {
                   itemCount: reshapedContactList.length,
                   physics: defaultScrollPhysics,
                   itemBuilder: (context, index) {
-                    var contactItem = reshapedContactList[index];
-                    return model.contact(context, contactItem,
-                        (context, contact, child) {
-                      var isUnaccepted = contact.isUnaccepted();
-                      return Column(
-                        children: [
-                          ListItemFactory.messagingItem(
-                            customBg: isUnaccepted ? customBg : null,
-                            header: unacceptedStartIndex == index
-                                ? 'new_requests'.i18n.fill([
-                                    '(${reshapedContactList.length - unacceptedStartIndex})'
-                                  ])
-                                : null,
-                            focusedMenu: !isUnaccepted
-                                ? renderLongTapMenu(
-                                    contact: contact, context: context)
-                                : null,
-                            leading: CustomAvatar(
-                                customColor: isUnaccepted ? grey5 : null,
-                                messengerId: contact.contactId.id,
-                                displayName: contact.displayNameOrFallback),
-                            content: contact.displayNameOrFallback,
-                            subtitle:
-                                '${contact.mostRecentMessageText.isNotEmpty ? contact.mostRecentMessageText : 'attachment'}'
-                                    .i18n,
-                            onTap: () async => await context.pushRoute(
-                                Conversation(contactId: contact.contactId)),
-                            trailingArray: [
-                              HumanizedDate.fromMillis(
-                                contact.mostRecentMessageTs.toInt(),
-                                builder: (context, date) => CText(date,
-                                    style: tsBody2.copiedWith(color: grey5)),
-                              )
-                            ],
-                          ),
-                        ],
-                      );
-                    });
+                    var contact = reshapedContactList[index].value;
+                    var isUnaccepted = contact.isUnaccepted();
+                    return Column(
+                      children: [
+                        ListItemFactory.messagingItem(
+                          customBg: isUnaccepted ? customBg : null,
+                          header: unacceptedStartIndex == index
+                              ? 'new_requests'.i18n.fill([
+                                  '(${reshapedContactList.length - unacceptedStartIndex})'
+                                ])
+                              : null,
+                          focusedMenu: !isUnaccepted
+                              ? renderLongTapMenu(
+                                  contact: contact, context: context)
+                              : null,
+                          leading: CustomAvatar(
+                              customColor: isUnaccepted ? grey5 : null,
+                              messengerId: contact.contactId.id,
+                              displayName: contact.displayNameOrFallback),
+                          content: contact.displayNameOrFallback,
+                          subtitle:
+                              '${contact.mostRecentMessageText.isNotEmpty ? contact.mostRecentMessageText : 'attachment'}'
+                                  .i18n,
+                          onTap: () async => await context.pushRoute(
+                              Conversation(contactId: contact.contactId)),
+                          trailingArray: [
+                            HumanizedDate.fromMillis(
+                              contact.mostRecentMessageTs.toInt(),
+                              builder: (context, date) => CText(date,
+                                  style: tsBody2.copiedWith(color: grey5)),
+                            )
+                          ],
+                        ),
+                      ],
+                    );
                   },
                 ),
               );


### PR DESCRIPTION
…that we have a chance to move unaccepted contacts to accepted

Closes getlantern/engineering#773 and may also fix getlantern/engineering#774.

The reason this wasn't working before is that by using `model.contact` on each row, when that single contact updated, the list did not update as a whole, bypassing the sorting/grouping logic. This change removes the call to `model.contact` to force the whole list to update every time. That's not as efficient, and we'll have to keep an eye out for whether that becomes a performance issue, but this should be okay for now.