### PR TITLE
Scroll entire New Chats view as one list

### DIFF
--- a/lib/messaging/contacts/grouped_contact_list.dart
+++ b/lib/messaging/contacts/grouped_contact_list.dart
@@ -11,13 +11,19 @@ ScrollablePositionedList groupedContactListGenerator({
   Function? trailingCallback,
   Function? onTapCallback,
   Function? focusMenuCallback,
+  List<Widget>? headItems,
 }) {
+  final numHeadItems = headItems?.length ?? 0;
   return ScrollablePositionedList.builder(
     itemScrollController: scrollListController,
     initialScrollIndex: initialScrollIndex,
     physics: defaultScrollPhysics,
-    itemCount: groupedSortedList!.length,
+    itemCount: groupedSortedList!.length + numHeadItems,
     itemBuilder: (context, index) {
+      if (index < numHeadItems) {
+        return headItems![index];
+      }
+      index -= numHeadItems;
       var key = groupedSortedList.keys.elementAt(index);
       var itemsPerKey = groupedSortedList.values.elementAt(index);
       return ListBody(

--- a/lib/messaging/contacts/new_chat.dart
+++ b/lib/messaging/contacts/new_chat.dart
@@ -64,143 +64,136 @@ class _NewChatState extends State<NewChat> {
       ],
       body: model.me(
         (BuildContext context, Contact me, Widget? child) {
-          return Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              /*
-              * Add via Chat Number
-              */
-              ListItemFactory.messagingItem(
-                header: 'add_new_contact'.i18n,
-                leading: const CAssetImage(
-                  path: ImagePaths.person_add_alt_1,
-                ),
-                content:
-                    CText('add_via_chat_number'.i18n, style: tsSubtitle1Short),
-                trailingArray: [
-                  mirrorLTR(
-                    context: context,
-                    child: const CAssetImage(
-                      path: ImagePaths.keyboard_arrow_right,
-                    ),
-                  )
-                ],
-                onTap: () async => await context
-                    .pushRoute(const AddViaChatNumber())
-                    .then(onContactAdded),
-              ),
-              /*
-              * Scan QR Code
-              */
-              ListItemFactory.messagingItem(
-                leading: const CAssetImage(
-                  path: ImagePaths.qr_code_scanner,
-                ),
-                content: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    CText('scan_qr_code'.i18n, style: tsSubtitle1Short),
-                    CText('add_contact_in_person'.i18n,
-                        style: tsBody1.copiedWith(color: grey5))
-                  ],
-                ),
-                trailingArray: [
-                  mirrorLTR(
-                    context: context,
-                    child: const CAssetImage(
-                      path: ImagePaths.keyboard_arrow_right,
-                    ),
-                  )
-                ],
-                onTap: () async => await context
-                    .pushRoute(
-                      FullScreenDialogPage(
-                          widget: AddViaQR(
-                        me: me,
-                        isVerificationMode: false,
-                      )),
-                    )
-                    .then(onContactAdded),
-              ),
-              /*
-              * Share your Chat Number
-              */
-              ListItemFactory.messagingItem(
-                leading: const CAssetImage(
-                  path: ImagePaths.share,
-                ),
-                content: CText('share_your_chat_number'.i18n,
-                    style: tsSubtitle1Short),
-                trailingArray: [
-                  mirrorLTR(
-                    context: context,
-                    child: const CAssetImage(
-                      path: ImagePaths.keyboard_arrow_right,
-                    ),
-                  )
-                ],
-                onTap: () =>
-                    Share.share(me.chatNumber.shortNumber.formattedChatNumber),
-              ),
-              /*
-              * Contact List
-              */
-              Flexible(child: model.contacts(builder: (context,
-                  Iterable<PathAndValue<Contact>> _contacts, Widget? child) {
-                var contacts = _contacts
-                    .where((element) =>
-                        element.value.isAccepted() &&
-                        element.value.isNotBlocked())
-                    .toList();
+          return model.contacts(builder: (context,
+              Iterable<PathAndValue<Contact>> _contacts, Widget? child) {
+            var contacts = _contacts
+                .where((element) =>
+                    element.value.isAccepted() && element.value.isNotBlocked())
+                .toList();
 
-                // related https://github.com/getlantern/android-lantern/issues/299
-                var sortedContacts = contacts.sortedAlphabetically();
+            // related https://github.com/getlantern/android-lantern/issues/299
+            var sortedContacts = contacts.sortedAlphabetically();
 
-                var groupedSortedContacts = sortedContacts.groupBy(
-                    (el) => el.value.displayNameOrFallback[0].toLowerCase());
+            var groupedSortedContacts = sortedContacts.groupBy(
+                (el) => el.value.displayNameOrFallback[0].toLowerCase());
 
-                // scroll to index of the contact we just added, if there is one
-                // otherwise start from top (index = 0)
-                var scrollIndex = _updatedContact != null
-                    ? sortedContacts.indexWhere((element) =>
-                        element.value.contactId.id ==
-                        _updatedContact!.contactId.id)
-                    : 0;
-                if (scrollListController.isAttached) {
-                  scrollListController.scrollTo(
-                      index: scrollIndex != -1 ? scrollIndex : 0,
-                      //if recent contact can not be found in our list for some reason
-                      duration: const Duration(milliseconds: 300));
-                }
+            // scroll to index of the contact we just added, if there is one
+            // otherwise start from top (index = 0)
+            var scrollIndex = _updatedContact != null
+                ? sortedContacts.indexWhere((element) =>
+                    element.value.contactId.id == _updatedContact!.contactId.id)
+                : 0;
+            if (scrollListController.isAttached) {
+              scrollListController.scrollTo(
+                  index: scrollIndex != -1 ? scrollIndex : 0,
+                  //if recent contact can not be found in our list for some reason
+                  duration: const Duration(milliseconds: 300));
+            }
 
-                return groupedSortedContacts.isNotEmpty
-                    ? groupedContactListGenerator(
-                        groupedSortedList: groupedSortedContacts,
-                        scrollListController: scrollListController,
-                        leadingCallback: (Contact contact) => CustomAvatar(
-                            messengerId: contact.contactId.id,
-                            displayName: contact.displayNameOrFallback),
-                        onTapCallback: (Contact contact) async =>
-                            await context.pushRoute(
-                                Conversation(contactId: contact.contactId)),
-                        focusMenuCallback: (Contact contact) =>
-                            renderLongTapMenu(
-                                contact: contact, context: context))
-                    : Container(
-                        alignment: AlignmentDirectional.center,
-                        padding: const EdgeInsetsDirectional.all(16.0),
-                        child: CText('no_contacts_yet'.i18n,
-                            textAlign: TextAlign.center,
-                            style:
-                                tsSubtitle1Short)); // rendering this instead of SizedBox() to avoid null dimension errors
-              })),
-            ],
-          );
+            return groupedSortedContacts.isNotEmpty
+                ? groupedContactListGenerator(
+                    headItems: buildNewChatItems(me),
+                    groupedSortedList: groupedSortedContacts,
+                    scrollListController: scrollListController,
+                    leadingCallback: (Contact contact) => CustomAvatar(
+                        messengerId: contact.contactId.id,
+                        displayName: contact.displayNameOrFallback),
+                    onTapCallback: (Contact contact) async => await context
+                        .pushRoute(Conversation(contactId: contact.contactId)),
+                    focusMenuCallback: (Contact contact) =>
+                        renderLongTapMenu(contact: contact, context: context))
+                : Container(
+                    alignment: AlignmentDirectional.center,
+                    padding: const EdgeInsetsDirectional.all(16.0),
+                    child: CText('no_contacts_yet'.i18n,
+                        textAlign: TextAlign.center,
+                        style:
+                            tsSubtitle1Short)); // rendering this instead of SizedBox() to avoid null dimension errors
+          });
         },
       ),
+    );
+  }
+
+  List<Widget> buildNewChatItems(Contact me) {
+    return [
+      buildAddViaChatNumber(me),
+      buildScanQRCode(me),
+      buildShareYourChatNumber(me),
+    ];
+  }
+
+  Widget buildAddViaChatNumber(Contact me) {
+    return ListItemFactory.messagingItem(
+      header: 'add_new_contact'.i18n,
+      leading: const CAssetImage(
+        path: ImagePaths.person_add_alt_1,
+      ),
+      content: CText('add_via_chat_number'.i18n, style: tsSubtitle1Short),
+      trailingArray: [
+        mirrorLTR(
+          context: context,
+          child: const CAssetImage(
+            path: ImagePaths.keyboard_arrow_right,
+          ),
+        )
+      ],
+      onTap: () async => await context
+          .pushRoute(const AddViaChatNumber())
+          .then(onContactAdded),
+    );
+  }
+
+  Widget buildScanQRCode(Contact me) {
+    return ListItemFactory.messagingItem(
+      leading: const CAssetImage(
+        path: ImagePaths.qr_code_scanner,
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CText('scan_qr_code'.i18n, style: tsSubtitle1Short),
+          CText('add_contact_in_person'.i18n,
+              style: tsBody1.copiedWith(color: grey5))
+        ],
+      ),
+      trailingArray: [
+        mirrorLTR(
+          context: context,
+          child: const CAssetImage(
+            path: ImagePaths.keyboard_arrow_right,
+          ),
+        )
+      ],
+      onTap: () async => await context
+          .pushRoute(
+            FullScreenDialogPage(
+                widget: AddViaQR(
+              me: me,
+              isVerificationMode: false,
+            )),
+          )
+          .then(onContactAdded),
+    );
+  }
+
+  Widget buildShareYourChatNumber(Contact me) {
+    return ListItemFactory.messagingItem(
+      leading: const CAssetImage(
+        path: ImagePaths.share,
+      ),
+      content: CText('share_your_chat_number'.i18n, style: tsSubtitle1Short),
+      trailingArray: [
+        mirrorLTR(
+          context: context,
+          child: const CAssetImage(
+            path: ImagePaths.keyboard_arrow_right,
+          ),
+        )
+      ],
+      onTap: () => Share.share(me.chatNumber.shortNumber.formattedChatNumber),
     );
   }
 }


### PR DESCRIPTION
Prior to this change, the list of contacts under the "Add New Contact" section is in its own scroll view, meaning that we only ever use that bottom part of the screen for the contacts.

This fixes that so the "Add New Contact" elements are simply part of the list.