### PR TITLE
Pin older version of emoji picker to reduce glitchiness

### DIFF
--- a/lib/messaging/conversation/messaging_emoji_picker.dart
+++ b/lib/messaging/conversation/messaging_emoji_picker.dart
@@ -23,14 +23,15 @@ class MessagingEmojiPicker extends StatelessWidget {
       child: LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
         return Padding(
-          padding: const EdgeInsetsDirectional.only(start: 8.0, end: 8.0),
+          padding: const EdgeInsetsDirectional.only(
+              start: 8.0, end: 8.0, bottom: 8.0),
           child: ep.EmojiPicker(
             key: key,
             onBackspacePressed: onBackspacePressed,
             onEmojiSelected: onEmojiSelected,
             config: ep.Config(
               initCategory: ep.Category.SMILEYS,
-              columns: constraints.maxWidth ~/ 40.0,
+              columns: constraints.maxWidth ~/ 50.0,
               iconColor: grey5,
               iconColorSelected: black,
               noRecentsStyle: TextStyle(fontSize: 15, color: black),
@@ -38,8 +39,6 @@ class MessagingEmojiPicker extends StatelessWidget {
               noRecentsText: emptySuggestions,
               bgColor: white,
               indicatorColor: grey5,
-              horizontalSpacing: 8,
-              verticalSpacing: 8,
             ),
           ),
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,7 +83,8 @@ dependencies:
 
   dotted_border: ^2.0.0
 
-  emoji_picker_flutter: ^1.0.6
+  # Version 1.0.7 seems glitchy, so we're using 1.0.6 explicitly
+  emoji_picker_flutter: 1.0.6
 
   email_validator: '^2.0.1'
 


### PR DESCRIPTION
Closes getlantern/engineering#772.

- [ ] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [ ] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [ ] All text styles are defined in `text_styles.dart` and are not duplicated
- [ ] All icons are using the vector resource from Figma (do not use built-in Icons)
- [ ] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [ ] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
