### PR TITLE
Fix opening AccountManagement from Chats

### DIFF
--- a/lib/messaging/chats.dart
+++ b/lib/messaging/chats.dart
@@ -111,8 +111,8 @@ class _ChatsState extends State<Chats> {
           RoundButton(
             onPressed: () async => showBottomModal(context: context, children: [
               model.me(
-                (context, me, child) => sessionModel.proUser(
-                    (context, isPro, child) => ListItemFactory.bottomItem(
+                (_, me, child) => sessionModel
+                    .proUser((_, isPro, child) => ListItemFactory.bottomItem(
                           icon: ImagePaths.account,
                           content: 'account_management'.i18n,
                           onTap: () async {


### PR DESCRIPTION
Closes getlantern/engineering#1017.

I think it was getting messed up by the nested contexts from the future builders. Using the same context with which we opened the modal bottom sheet seems to have resolved it.

- [ ] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [ ] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [ ] All text styles are defined in `text_styles.dart` and are not duplicated
- [ ] All icons are using the vector resource from Figma (do not use built-in Icons)
- [ ] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [ ] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
