### PR TITLE
Call closing improvements

### DIFF
--- a/lib/messaging/calls/call.dart
+++ b/lib/messaging/calls/call.dart
@@ -22,6 +22,7 @@ class _CallState extends State<Call> with WidgetsBindingObserver {
   var isPanelShowing = false;
   var isVerified = false;
   var fragmentStatusMap = {};
+  var incoming = false;
 
   @override
   void initState() {
@@ -37,6 +38,7 @@ class _CallState extends State<Call> with WidgetsBindingObserver {
 
     if (widget.initialSession != null) {
       session = Future.value(widget.initialSession!);
+      incoming = true;
     } else {
       session = signaling.call(
         peerId: widget.contact.contactId.id,
@@ -68,9 +70,17 @@ class _CallState extends State<Call> with WidgetsBindingObserver {
     if (signaling.value.callState == CallState.Bye) {
       if (!closed) {
         /*
-        * Popping back to wherever we were by indicating that we have verified the contact
+        *
         */
-        Navigator.pop(context, isVerified);
+        if (incoming) {
+          // For incoming calls, open the conversation corresponding to this
+          // the contact with whom we were just on a call.
+          await context.router
+              .replace(Conversation(contactId: widget.contact.contactId));
+        } else {
+          // Pop back to wherever we were, whether or not we've verified the contact.
+          Navigator.pop(context, isVerified);
+        }
         closed = true;
       }
     }

--- a/lib/messaging/conversation/show_verification_options.dart
+++ b/lib/messaging/conversation/show_verification_options.dart
@@ -60,7 +60,7 @@ void showVerificationOptions({
             )
                 .then((value) async {
               // * we just successfully verified someone via a Call
-              if (value != null) {
+              if (value == true) {
                 verificationUX();
               }
             });


### PR DESCRIPTION
Closes getlantern/engineering#787 and getlantern/engineering#789.

- [ ] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [ ] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [ ] All text styles are defined in `text_styles.dart` and are not duplicated
- [ ] All icons are using the vector resource from Figma (do not use built-in Icons)
- [ ] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [ ] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
