### PR TITLE
Fix notifications on Android 7 and below

### DIFF
--- a/android/app/src/main/java/org/getlantern/lantern/model/MessagingHolder.kt
+++ b/android/app/src/main/java/org/getlantern/lantern/model/MessagingHolder.kt
@@ -121,10 +121,17 @@ class MessagingHolder {
             }
             messaging.db.get<Model.Contact>(msg.senderId.directContactPath)
             contact?.let {
-                if (contact.contactId.id == MessagingModel.currentConversationContact) {
-                    // don't notify if we're currently viewing the relevant conversation
-                    return@let
+                MessagingModel.currentConversationContact?.let { current ->
+                    if (System.currentTimeMillis() - current.ts < 5000) {
+                        // it's been less than 5 seconds since the currentConversationContact was
+                        // last set, assume it's still valid
+                        if (contact.contactId.id == current.contactId) {
+                            // don't notify since we're currently viewing the relevant conversation
+                            return@notifyMessage
+                        }
+                    }
                 }
+
                 if (contact.verificationLevel <= Model.VerificationLevel.UNACCEPTED &&
                     numberOfNotificationAttempts > 1
                 ) {

--- a/android/app/src/main/kotlin/io/lantern/android/model/MessagingModel.kt
+++ b/android/app/src/main/kotlin/io/lantern/android/model/MessagingModel.kt
@@ -21,6 +21,7 @@ import top.oply.opuslib.OpusRecorder
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileInputStream
+import java.sql.Timestamp
 import java.util.concurrent.atomic.AtomicReference
 
 class MessagingModel constructor(
@@ -109,8 +110,12 @@ class MessagingModel constructor(
             /*
             * Contacts
             */
-            "setCurrentConversationContact" -> currentConversationContact = (call.arguments as String)
-            "clearCurrentConversationContact" -> currentConversationContact = ""
+            "setCurrentConversationContact" ->
+                currentConversationContact = TimestampedContactId(
+                    System.currentTimeMillis(),
+                    call.arguments as String
+                )
+            "clearCurrentConversationContact" -> currentConversationContact = null
             "addProvisionalContact" -> messaging.addProvisionalContact(
                 call.argument("unsafeContactId")!!,
                 when (call.argument<Any>("source")) {
@@ -346,8 +351,10 @@ class MessagingModel constructor(
     }
 
     companion object {
-        var currentConversationContact = ""
+        var currentConversationContact: TimestampedContactId? = null
 
         val snippetHighlight = "**"
     }
 }
+
+data class TimestampedContactId(val ts: Long, val contactId: String)

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -33,6 +33,8 @@ class _HomePageState extends State<HomePage> {
     super.initState();
     final eventManager = EventManager('lantern_event_channel');
     navigationChannel.setMethodCallHandler(_handleNativeNavigationRequest);
+    // Let back-end know that we're ready to handle navigation
+    navigationChannel.invokeListMethod('ready');
     _cancelEventSubscription =
         eventManager.subscribe(Event.All, (eventName, params) {
       final event = EventParsing.fromValue(eventName);

--- a/lib/messaging/conversation/conversation.dart
+++ b/lib/messaging/conversation/conversation.dart
@@ -70,6 +70,8 @@ class ConversationState extends State<Conversation>
   double get defaultKeyboardHeight => MediaQuery.of(context).size.height * 0.4;
   static var latestKeyboardHeight = 0.0;
 
+  Timer? currentConversationTimer;
+
   void showNativeKeyboard() {
     focusNode.requestFocus();
   }
@@ -158,13 +160,25 @@ class ConversationState extends State<Conversation>
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:
-        model.clearCurrentConversationContact();
+        clearCurrentConversationContact();
         break;
       case AppLifecycleState.resumed:
       default:
         model.setCurrentConversationContact(widget.contactId.id);
+        // repeatedly notify backend of current contact so it knows that it's
+        // fresh
+        currentConversationTimer = Timer.periodic(
+          const Duration(seconds: 1),
+          (_) => model.setCurrentConversationContact(widget.contactId.id),
+        );
         break;
     }
+  }
+
+  void clearCurrentConversationContact() {
+    currentConversationTimer?.cancel();
+    currentConversationTimer = null;
+    model.clearCurrentConversationContact();
   }
 
   @override
@@ -196,7 +210,7 @@ class ConversationState extends State<Conversation>
   @override
   void dispose() {
     WidgetsBinding.instance!.removeObserver(this);
-    model.clearCurrentConversationContact();
+    clearCurrentConversationContact();
     newMessage.dispose();
     stopWatchTimer.dispose();
     focusNode.dispose();


### PR DESCRIPTION
Closes getlantern/engineering#985.

I tested this on my Huawei running Android 10, and an emulator running Android 7.1. Without this fix, notifications do not appear on the Android 7.1 emulator.

- [ ] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [ ] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [ ] All text styles are defined in `text_styles.dart` and are not duplicated
- [ ] All icons are using the vector resource from Figma (do not use built-in Icons)
- [ ] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [ ] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
