### PR TITLE
Made message bar expand up to 4 rows

### DIFF
--- a/lib/messaging/conversation/audio/message_bar_preview_recording.dart
+++ b/lib/messaging/conversation/audio/message_bar_preview_recording.dart
@@ -51,10 +51,13 @@ class MessageBarPreviewRecording extends StatelessWidget {
       children[0] = deleteButton;
       children[1] = audioWidget;
     }
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: children,
+    return Container(
+      height: messageBarHeight,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: children,
+      ),
     );
   }
 }

--- a/lib/messaging/conversation/conversation.dart
+++ b/lib/messaging/conversation/conversation.dart
@@ -472,11 +472,15 @@ class ConversationState extends State<Conversation>
                   onCancelReply: () => setState(() => quotedMessage = null),
                 ),
               Divider(height: 1.0, color: grey3),
-              Container(
-                color: isRecording ? grey2 : white,
-                width: MediaQuery.of(context).size.width,
-                height: messageBarHeight,
-                child: buildMessageBar(),
+              ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: messageBarHeight,
+                ),
+                child: Container(
+                  color: isRecording ? grey2 : white,
+                  width: MediaQuery.of(context).size.width,
+                  child: buildMessageBar(),
+                ),
               ),
               // * Emoji keyboard
               Offstage(
@@ -702,35 +706,34 @@ class ConversationState extends State<Conversation>
     final content = Stack(
       alignment: Alignment.center,
       children: [
-        TextFormField(
-          expands: true,
-          minLines: null,
-          maxLines: null,
-          textAlignVertical: TextAlignVertical.center,
-          autofocus: false,
-          textInputAction: TextInputAction.send,
-          controller: newMessage,
-          onChanged: (value) {
-            final newIsSendIconVisible = value.isNotEmpty;
-            if (newIsSendIconVisible != isSendIconVisible) {
-              setState(() => isSendIconVisible = newIsSendIconVisible);
-            }
-          },
-          focusNode: focusNode,
-          textCapitalization: TextCapitalization.sentences,
-          onFieldSubmitted: (value) async =>
-              value.isEmpty ? null : await handleMessageBarSubmit(newMessage),
-          decoration: InputDecoration(
-            // Send icon
-            enabledBorder: InputBorder.none,
-            focusedBorder: InputBorder.none,
-            hintText: 'message'.i18n,
-            border: const OutlineInputBorder(),
+        if (!isRecording)
+          TextFormField(
+            minLines: 1,
+            maxLines: 4,
+            autofocus: false,
+            textInputAction: TextInputAction.send,
+            controller: newMessage,
+            onChanged: (value) {
+              final newIsSendIconVisible = value.isNotEmpty;
+              if (newIsSendIconVisible != isSendIconVisible) {
+                setState(() => isSendIconVisible = newIsSendIconVisible);
+              }
+            },
+            focusNode: focusNode,
+            textCapitalization: TextCapitalization.sentences,
+            onFieldSubmitted: (value) async =>
+                value.isEmpty ? null : await handleMessageBarSubmit(newMessage),
+            decoration: InputDecoration(
+              // Send icon
+              enabledBorder: InputBorder.none,
+              focusedBorder: InputBorder.none,
+              hintText: 'message'.i18n,
+              border: const OutlineInputBorder(),
+            ),
+            style: tsSubtitle1
+                .copiedWith(color: isSendIconVisible ? black : grey5)
+                .short,
           ),
-          style: tsSubtitle1
-              .copiedWith(color: isSendIconVisible ? black : grey5)
-              .short,
-        ),
         // hide TextFormField while recording by painting over it. this allows
         // the form field to retain focus to keep the keyboard open and keep
         // the layout from changing while we're recording.
@@ -777,8 +780,8 @@ class ConversationState extends State<Conversation>
     return Stack(
       alignment: isLTR(context) ? Alignment.bottomRight : Alignment.bottomLeft,
       children: [
-        Container(
-            height: messageBarHeight,
+        ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: messageBarHeight),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [


### PR DESCRIPTION
- [ ] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [ ] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [ ] All text styles are defined in `text_styles.dart` and are not duplicated
- [ ] All icons are using the vector resource from Figma (do not use built-in Icons)
- [ ] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [ ] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
