### PR TITLE
removed bintray, added support for new flashlight

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -292,11 +292,9 @@ repositories {
     flatDir {
         dirs 'libs'
     }
-    jcenter()
     google()
     mavenCentral()
     mavenLocal()
-    maven { url  "https://dl.bintray.com/piasy/maven" }
     maven { url "https://www.jitpack.io" }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url 'https://maven.google.com' }
         maven { url 'https://jitpack.io' }
@@ -53,7 +52,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"

--- a/internalsdk/android.go
+++ b/internalsdk/android.go
@@ -268,11 +268,12 @@ type userConfig struct {
 	session panickingSession
 }
 
-func (uc *userConfig) GetDeviceID() string          { return uc.session.GetDeviceID() }
-func (uc *userConfig) GetUserID() int64             { return uc.session.GetUserID() }
-func (uc *userConfig) GetToken() string             { return uc.session.GetToken() }
-func (uc *userConfig) GetLanguage() string          { return uc.session.Locale() }
-func (uc *userConfig) GetTimeZone() (string, error) { return uc.session.GetTimeZone(), nil }
+func (uc *userConfig) GetDeviceID() string             { return uc.session.GetDeviceID() }
+func (uc *userConfig) GetUserID() int64                { return uc.session.GetUserID() }
+func (uc *userConfig) GetToken() string                { return uc.session.GetToken() }
+func (uc *userConfig) GetLanguage() string             { return uc.session.Locale() }
+func (uc *userConfig) GetTimeZone() (string, error)    { return uc.session.GetTimeZone(), nil }
+func (uc *userConfig) GetEnabledExperiments() []string { return nil }
 func (uc *userConfig) GetInternalHeaders() map[string]string {
 	h := make(map[string]string)
 


### PR DESCRIPTION
Bintray is now more down than up, and it's causing build issues. I've just removed it, since it's contents are mirrored in mavenCenter.
I've also added one stub method to be compatible with newer flashlight code

- [ ] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [ ] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [ ] All text styles are defined in `text_styles.dart` and are not duplicated
- [ ] All icons are using the vector resource from Figma (do not use built-in Icons)
- [ ] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [ ] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
