### PR TITLE
[internalsdk:replica|backend] Enable Replica through global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Lantern Android is an app that uses the [VpnService][https://developer.android.c
 
 This project is meant to be used inside of the context of a local clone of https://github.com/getlantern/lantern-build.
 
+### Enabling Replica
+
+Whether Replica is enabled or not is determined like this:
+- mobilesdk/Settings.java has a flag called `replicaEnabledState` of type `ReplicaEnabledState`
+  - `ReplicaEnabledState` has three states:
+    - `YES` - Always enabled, regardless of what global config says
+    - `NO` - Always disabled, regardless of what global config says
+    - `GLOBAL_CONFIG` - Depends whether your country in global config has the Replica feature enabled:
+      - See here for enabled countries https://github.com/getlantern/lantern_aws/blob/c1896cf884a4a91d15a61f8a1695fe2bf713f512/salt/update_masquerades/cloud.yaml.tmpl#L73
+
 ## Acknowledgements
 
 This application uses ringtone sounds from Mike Koenig available [here](https://soundbible.com/1868-Ringing-Phone.html)

--- a/android/app/libs/liblantern-all.aar
+++ b/android/app/libs/liblantern-all.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:703bcd9a408c862225109b8c4a91a7a16e1a79cb058ae580a915062ee267368a
-size 50199624
+oid sha256:2b5a886649b83007db87d35fbaad2b13ed2f5ede791ba101af4edd0e8861d226
+size 50199455

--- a/android/app/src/androidTest/java/org/getlantern/lantern/test/ReplicaTest.java
+++ b/android/app/src/androidTest/java/org/getlantern/lantern/test/ReplicaTest.java
@@ -13,6 +13,7 @@ import org.getlantern.lantern.R;
 import org.getlantern.mobilesdk.Settings;
 import org.getlantern.mobilesdk.StartResult;
 import org.getlantern.mobilesdk.embedded.EmbeddedLantern;
+import org.getlantern.mobilesdk.features.ReplicaEnabledState;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +38,7 @@ public class ReplicaTest extends BaseTest {
         // Initialize internalsdk
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         Settings settings = Settings.init(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        settings.shouldRunReplica = true;
+        settings.replicaEnabledState = ReplicaEnabledState.YES;
         StartResult result = new EmbeddedLantern().start(
                 Paths.get(context.getFilesDir().getAbsolutePath(), ".lantern").toString(),
                 "en_US", settings, LanternApp.getSession());

--- a/android/app/src/main/java/org/getlantern/mobilesdk/Settings.java
+++ b/android/app/src/main/java/org/getlantern/mobilesdk/Settings.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import com.google.gson.annotations.SerializedName;
 
 import org.getlantern.lantern.util.Json;
+import org.getlantern.mobilesdk.features.ReplicaEnabledState;
 
 import java.io.InputStream;
 
@@ -26,10 +27,8 @@ public class Settings implements internalsdk.Settings {
     private long startTimeoutMillis;
 
     // Declare as transient so that Gson ignores this
-    // TODO <13-10-21, soltzen> We'll set this to true always in the future,
-    // when Replica is ready on mobile. For now, just keep it public and easy
-    // to work with
-    public transient boolean shouldRunReplica = true;
+    // XXX <16-12-21, soltzen> See the 'Enabling Replica' section in the README for more info
+    public transient ReplicaEnabledState replicaEnabledState = ReplicaEnabledState.GLOBAL_CONFIG;
 
     public static Settings init(final Context context) {
         try {
@@ -62,7 +61,7 @@ public class Settings implements internalsdk.Settings {
         return httpProxyPort;
     }
 
-    public boolean shouldRunReplica() {
-        return shouldRunReplica;
+    public long getReplicaEnabledState() {
+        return replicaEnabledState.getValue();
     }
 }

--- a/android/app/src/main/java/org/getlantern/mobilesdk/features/ReplicaEnabledState.java
+++ b/android/app/src/main/java/org/getlantern/mobilesdk/features/ReplicaEnabledState.java
@@ -1,0 +1,18 @@
+package org.getlantern.mobilesdk.features;
+
+// See 'Enabling Replica' section in the README for more info
+public enum ReplicaEnabledState {
+    YES(0), // Always enabled, regardless of what global config says
+    NO(1), // Always disabled, regardless of what global config says
+    GLOBAL_CONFIG(2); // Depends on global config
+
+    private final long value;
+
+    private ReplicaEnabledState(long value) {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/internalsdk/android_test.go
+++ b/internalsdk/android_test.go
@@ -33,12 +33,12 @@ type testSettings struct {
 	Settings
 }
 
-func (c testSettings) StickyConfig() bool       { return true }
-func (c testSettings) TimeoutMillis() int       { return 15000 }
-func (c testSettings) GetHttpProxyHost() string { return "127.0.0.1" }
-func (c testSettings) GetHttpProxyPort() int    { return 49128 }
-func (c testSettings) GetReplicaPort() int      { return 0 }
-func (c testSettings) ShouldRunReplica() bool   { return false }
+func (c testSettings) StickyConfig() bool          { return true }
+func (c testSettings) TimeoutMillis() int          { return 15000 }
+func (c testSettings) GetHttpProxyHost() string    { return "127.0.0.1" }
+func (c testSettings) GetHttpProxyPort() int       { return 49128 }
+func (c testSettings) GetReplicaPort() int         { return 0 }
+func (c testSettings) GetReplicaEnabledState() int { return REPLICAENABLED_YES }
 
 func (c testSession) AfterStart() error                        { return nil }
 func (c testSession) BandwidthUpdate(int, int, int, int) error { return nil }


### PR DESCRIPTION
Closes https://github.com/getlantern/grants/issues/443

@oxtoacart  need your help on this one.

See the 'Enabling Replica' section in the README for context.

When using `ReplicaEnabledState.GLOBAL_CONFIG`, the country is always nil. I've increased the timeout to [5 seconds](https://github.com/getlantern/android-lantern/blob/48109efdf17a587f87cb9b7c131edb632ce8b01a/internalsdk/replica.go#L40) and forced a [`geolookup.Refresh()`](https://github.com/getlantern/android-lantern/blob/48109efdf17a587f87cb9b7c131edb632ce8b01a/internalsdk/android.go#L476) in run(), but still no dice. Any thoughts on this? Can I use an alternative like Session.getCountryCode() reliably?

I'll clean the commits after we figure out a solution