### PR TITLE
Use application exclusion instead of socket protector to keep Lantern…

### DIFF
--- a/android/app/libs/liblantern-all.aar
+++ b/android/app/libs/liblantern-all.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c780fd31fa73f1b2aa5bab13c1c31ed62a452d02a9070438939e8efe79827e81
-size 54284979
+oid sha256:f5cbe3dcc4b6c705edb017a8c9b1b7f490fbc282a1c34065b568a6cf405000ea
+size 53433163

--- a/android/app/src/main/java/org/getlantern/lantern/vpn/GoTun2SocksProvider.java
+++ b/android/app/src/main/java/org/getlantern/lantern/vpn/GoTun2SocksProvider.java
@@ -2,6 +2,7 @@ package org.getlantern.lantern.vpn;
 
 import android.app.PendingIntent;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.VpnService;
 import android.os.ParcelFileDescriptor;
 
@@ -37,6 +38,13 @@ public class GoTun2SocksProvider implements Provider {
     builder.addAddress(privateAddress, 24);
     // route IPv4 through VPN
     builder.addRoute("0.0.0.0", 0);
+    // Don't capture traffic originating from Lantern itself in the VPN
+    String ourPackageName = vpnService.getPackageName();
+    try {
+      builder.addDisallowedApplication(ourPackageName);
+    } catch (PackageManager.NameNotFoundException e) {
+      throw new RuntimeException("Unable to exclude Lantern from routes", e);
+    }
     // don't currently route IPv6 through VPN because our proxies don't currently support IPv6
     // see https://github.com/getlantern/lantern-internal/issues/4961
     // Note - if someone performs a DNS lookup for an IPv6 only host like ipv6.google.com, dnsgrab

--- a/android/app/src/main/java/org/getlantern/lantern/vpn/LanternVpnService.java
+++ b/android/app/src/main/java/org/getlantern/lantern/vpn/LanternVpnService.java
@@ -116,22 +116,6 @@ public class LanternVpnService extends VpnService implements Runnable {
     public void run() {
         try {
             Logger.d(TAG, "Loading Lantern library");
-            Internalsdk.protectConnections(new SocketProtector() {
-                // Protect is used to exclude a socket specified by fileDescriptor
-                // from the VPN connection. Once protected, the underlying connection
-                // is bound to the VPN device and won't be forwarded
-                @Override
-                public void protectConn(long fileDescriptor) throws Exception {
-                    if (!protect((int) fileDescriptor)) {
-                        throw new Exception("protect socket failed");
-                    }
-                }
-
-                public String dnsServerIP() {
-                    return LanternApp.getSession().getDNSServer();
-                }
-            });
-
             getOrInitProvider().run(this, new Builder(), LanternApp.getSession().getSOCKS5Addr(), LanternApp.getSession().getDNSGrabAddr());
         } catch (Exception e) {
             e.printStackTrace();
@@ -169,12 +153,6 @@ public class LanternVpnService extends VpnService implements Runnable {
             EventBus.getDefault().post(new VpnState(false));
         } catch (Throwable t) {
             Logger.e(TAG, "error posting updated vpnstate", t);
-        }
-        try {
-            Logger.d(TAG, "removing overrides");
-            Internalsdk.removeOverrides();
-        } catch (Throwable t) {
-            Logger.e(TAG, "error removing overrides", t);
         }
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,6 @@ require (
 	github.com/getlantern/ipproxy v0.0.0-20201020142114-ed7e3a8d5d87
 	github.com/getlantern/memhelper v0.0.0-20181113170838-777ea7552231
 	github.com/getlantern/mtime v0.0.0-20200417132445-23682092d1f7
-	github.com/getlantern/netx v0.0.0-20211206143627-7ccfeb739cbd
-	github.com/getlantern/protected v0.0.0-20220224141403-67d8ee971ae8
 	github.com/getlantern/replica v0.9.2
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.7.1
@@ -25,6 +23,7 @@ require (
 require (
 	github.com/getlantern/eventual/v2 v2.0.2
 	github.com/getlantern/idletiming v0.0.0-20201229174729-33d04d220c4e
+	github.com/miekg/dns v1.1.43 // indirect
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
 	golang.org/x/tools v0.1.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -156,7 +156,6 @@ github.com/anacrolix/dht/v2 v2.10.5-0.20210902001729-06cc4fe90e53/go.mod h1:zHji
 github.com/anacrolix/dht/v2 v2.10.6-0.20211007004332-99263ec9c1c8/go.mod h1:WID4DexLrucfnwzv1OV8REzgoCpyVDwEczxIOrUeFrY=
 github.com/anacrolix/dht/v2 v2.14.1-0.20211220010335-4062f7927abf/go.mod h1:zJgaiAU2yhzmchZE2mY8WyZ64LK/F/D9MAeN0ct73qQ=
 github.com/anacrolix/dht/v2 v2.15.2-0.20220123034220-0538803801cb/go.mod h1:GCylVI6WTvbxvhY7pBoHiE5dmjfDWkhqbobDpjND01A=
-github.com/anacrolix/dht/v2 v2.16.2-0.20220311024416-dd658f18fd51 h1:issCwqC43gQ7n0gg9rn0EeVYXnQMI7vlnWub4oidtlU=
 github.com/anacrolix/dht/v2 v2.16.2-0.20220311024416-dd658f18fd51/go.mod h1:osiyaNrMLG9dw7wUtVMaII/NdCjlXeHjUcYzXnmop68=
 github.com/anacrolix/dht/v2 v2.18.0 h1:btjVjzjKqO5nKGbJHJ2UmuwiRx+EgX3e+OCHC9+WRz8=
 github.com/anacrolix/dht/v2 v2.18.0/go.mod h1:mxrSeP/LIY429SgWMO9o6UdjBjB8ZjBh6HHCmd8Ly1g=
@@ -189,7 +188,6 @@ github.com/anacrolix/log v0.10.0/go.mod h1:s5yBP/j046fm9odtUTbHOfDUq/zh1W8OkPpJt
 github.com/anacrolix/log v0.10.1-0.20220123034749-3920702c17f8/go.mod h1:GmnE2c0nvz8pOIPUSC9Rawgefy1sDXqposC2wgtBZE4=
 github.com/anacrolix/log v0.11.0/go.mod h1:D4+CvN8SnruK6zIFS/xPoRJmtvtnxs+CSfDQ+BFxZ68=
 github.com/anacrolix/log v0.13.0/go.mod h1:D4+CvN8SnruK6zIFS/xPoRJmtvtnxs+CSfDQ+BFxZ68=
-github.com/anacrolix/log v0.13.1 h1:BmVwTdxHd5VcNrLylgKwph4P4wf+5VvPgOK4yi91fTY=
 github.com/anacrolix/log v0.13.1/go.mod h1:D4+CvN8SnruK6zIFS/xPoRJmtvtnxs+CSfDQ+BFxZ68=
 github.com/anacrolix/log v0.13.2-0.20220426014722-7b7d13a55d55 h1:22o7jDD18WtIYUa2I983X58o6t8e9GVbcdYOKoy+Y4g=
 github.com/anacrolix/log v0.13.2-0.20220426014722-7b7d13a55d55/go.mod h1:D4+CvN8SnruK6zIFS/xPoRJmtvtnxs+CSfDQ+BFxZ68=
@@ -555,10 +553,6 @@ github.com/getlantern/fdcount v0.0.0-20210503151800-5decd65b3731/go.mod h1:XZwE+
 github.com/getlantern/filepersist v0.0.0-20160317154340-c5f0cd24e799/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c h1:mcz27xtAkb1OuOLBct/uFfL1p3XxAIcFct82GbT+UZM=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
-github.com/getlantern/flashlight v0.0.0-20220707144117-d489ebf11889 h1:gXccxbTbTE5T1oZxxA55BF7lak2pHKockQIyO+ndBMY=
-github.com/getlantern/flashlight v0.0.0-20220707144117-d489ebf11889/go.mod h1:hpDYFi+M58kOUcUYl3Leo2IIASpm1GmkFY45xA9Vxn4=
-github.com/getlantern/flashlight v0.0.0-20220714122355-2565e61ccbe5 h1:JqBtH4vaC5p3IbaKjw4Hs6h+VxEWnht+zOuJETCsigw=
-github.com/getlantern/flashlight v0.0.0-20220714122355-2565e61ccbe5/go.mod h1:alAEV8/QMSsgc0+CnV7ZitijMo2R+b8H/7UmllPflvM=
 github.com/getlantern/flashlight v0.0.0-20220714140548-37d19c44a108 h1:QuEvPMPk48CiT/FNlEXN8Qt2JtIXzcLlIQiwBdPEJ6c=
 github.com/getlantern/flashlight v0.0.0-20220714140548-37d19c44a108/go.mod h1:alAEV8/QMSsgc0+CnV7ZitijMo2R+b8H/7UmllPflvM=
 github.com/getlantern/framed v0.0.0-20190601192238-ceb6431eeede h1:yrU6Px3ZkvCsDLPryPGi6FN+2iqFPq+JeCb7EFoDBhw=
@@ -699,8 +693,6 @@ github.com/getlantern/probednet v0.0.0-20190725133252-1cfdb2354b4d/go.mod h1:7sl
 github.com/getlantern/probednet v0.0.0-20200930023717-dd97fef56a97/go.mod h1:noglym51kFdkZEV/WjiIzRKV6qwwTI9/vSAjeOI/zCU=
 github.com/getlantern/probednet v0.0.0-20211216020507-22fd9c1d3bf6 h1:8jg6OehdQr90Ybmyc68raXEqM/1hk8E7F2YAUfmcvzE=
 github.com/getlantern/probednet v0.0.0-20211216020507-22fd9c1d3bf6/go.mod h1:noglym51kFdkZEV/WjiIzRKV6qwwTI9/vSAjeOI/zCU=
-github.com/getlantern/protected v0.0.0-20220224141403-67d8ee971ae8 h1:MUXIHzkDx9H3UDMzylSzqLLiOxoaLSVMNyjBqdPcf8g=
-github.com/getlantern/protected v0.0.0-20220224141403-67d8ee971ae8/go.mod h1:B+WG9wugTdW6/fCuilOJ7gZAPI9tACGWYkLnijoMpOY=
 github.com/getlantern/proxy/v2 v2.0.0/go.mod h1:jU6qNaMq92qDY0slT9afuER7arXLnh7jU+DTg3W/oDs=
 github.com/getlantern/proxy/v2 v2.0.1-0.20220303164029-b34b76e0e581 h1:7NrSoq9ce/n15O+0smA756lo86c+coYoyGAhefRJCPw=
 github.com/getlantern/proxy/v2 v2.0.1-0.20220303164029-b34b76e0e581/go.mod h1:81jIwwI/5NGYj2CSvbsZapcTe87jd6AeEu6yJD1NKIg=
@@ -1831,7 +1823,6 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
-golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220328175248-053ad81199eb h1:pC9Okm6BVmxEw76PUu0XUbOTQ92JX11hfvqTjAV3qxM=
 golang.org/x/exp v0.0.0-20220328175248-053ad81199eb/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
@@ -1860,7 +1851,6 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 h1:LQmS1nU0twXLA96Kt7U9qtHJEbBk3z6Q0V4UXjZkpr4=
 golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=

--- a/internalsdk/android.go
+++ b/internalsdk/android.go
@@ -32,8 +32,6 @@ import (
 	"github.com/getlantern/golog"
 	"github.com/getlantern/memhelper"
 	"github.com/getlantern/mtime"
-	"github.com/getlantern/netx"
-	"github.com/getlantern/protected"
 
 	// import gomobile just to make sure it stays in go.mod
 	_ "golang.org/x/mobile/bind/java"
@@ -334,32 +332,6 @@ type SocketProtector interface {
 	// The DNS server is used to resolve host only when dialing a protected connection
 	// from within Lantern client.
 	DNSServerIP() string
-}
-
-// ProtectConnections allows connections made by Lantern to be protected from
-// routing via a VPN. This is useful when running Lantern as a VPN on Android,
-// because it keeps Lantern's own connections from being captured by the VPN and
-// resulting in an infinite loop.
-
-func ProtectConnections(protector SocketProtector) {
-	log.Debug("Protecting connections")
-	p := protected.New(protector.ProtectConn, protector.DNSServerIP)
-	netx.OverrideDial(p.DialContext)
-	netx.OverrideDialUDP(p.DialUDP)
-	netx.OverrideResolveIPs(p.ResolveIPs)
-	netx.OverrideListenUDP(p.ListenUDP)
-	bal := getBalancer(0)
-	if bal != nil {
-		log.Debug("Protected after balancer already created, force redial")
-		bal.ResetFromExisting()
-	}
-}
-
-// RemoveOverrides removes the protected tlsdialer overrides
-// that allowed connections to bypass the VPN.
-func RemoveOverrides() {
-	log.Debug("Removing overrides")
-	netx.Reset()
 }
 
 func getBalancer(timeout time.Duration) *balancer.Balancer {

--- a/internalsdk/tun.go
+++ b/internalsdk/tun.go
@@ -13,7 +13,6 @@ import (
 	"github.com/getlantern/errors"
 	"github.com/getlantern/idletiming"
 	"github.com/getlantern/ipproxy"
-	"github.com/getlantern/netx"
 
 	"golang.org/x/net/proxy"
 )
@@ -70,7 +69,8 @@ func Tun2Socks(fd int, socksAddr, dnsGrabAddr string, mtu int) error {
 				// we blackhole this traffic.
 				return nil, errors.New("blackholing QUIC UDP traffic to %v", addr)
 			}
-			conn, err := netx.DialContext(ctx, network, addr)
+			var d net.Dialer
+			conn, err := d.DialContext(ctx, network, addr)
 			if isDNS && err == nil {
 				// wrap our DNS requests in a connection that closes immediately to avoid piling up file descriptors for DNS requests
 				conn = idletiming.Conn(conn, 10*time.Second, nil)


### PR DESCRIPTION
… connections from being captured by VPN

This accomplishes two main things:

1. It solves an intermittent problem whereby the Replica video player's traffic gets captured by the VPN and the flashlight code is unable to connect to the local Replica listener that's on localhost

2. It dramatically simplifies our code because we don't have to worry about using netx to plug in to the socket protection mechanism.