### PR TITLE
When downloading an update fails, display the correct message, with a…

### DIFF
--- a/android/app/src/main/java/org/getlantern/lantern/model/Utils.java
+++ b/android/app/src/main/java/org/getlantern/lantern/model/Utils.java
@@ -244,6 +244,8 @@ public class Utils {
                         });
                 if (!activity.isFinishing()) {
                     alertDialog.show();
+                    // Make the message clickable in case it has embedded links
+                    ((TextView) alertDialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance());
                 }
                 alertDialog.setCancelable(cancelable);
             }

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">خطأ في تنزيل التحديث</string>
   <string name="error_install_update">خطأ في تثبيت التحديث</string>
   <string name="loading">جاري التحميل..</string>
-  <string name="manual_update">جرب تثبيت أحدث نسخة من لانترن هنا &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">جرب تثبيت أحدث نسخة من لانترن هنا &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">مرحبا بك في لانترن برو!</string>
   <string name="happy_anniversary">ذكري سنوية سعيد لـ لانترن!</string>
   <string name="welcome_greeting">مرحبا في لانتيرن</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -85,7 +85,7 @@
   <string name="not_now">İndi Yox</string>
   <string name="install_update">Yenilə</string>
   <string name="error_update">Yenilənmənin Yüklənməsində Xəta</string>
-  <string name="manual_update">Yeni versiyanı yükləmək üçün &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Yeni versiyanı yükləmək üçün &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Lantern Pro-ya xoş gəldiniz!</string>
   <string name="welcome_to_lantern">Yenilənmiş Lanternə xoş gəldiniz</string>
   <string name="to_get_unlimited">Limitsiz məzmun, əla sürət və daha yaxşı blokaçma imkanlarını\nYENİLƏMƏ ilə PRoda əldə edin!</string>

--- a/android/app/src/main/res/values-bn/strings.xml
+++ b/android/app/src/main/res/values-bn/strings.xml
@@ -106,7 +106,7 @@
   <string name="error_update">আপডেট ডাউনলোড করতে ত্রৃটি</string>
   <string name="error_install_update">আপডেট ইনস্টল করা সংক্রান্ত ত্রুটি</string>
   <string name="loading">লোড হচ্ছে...</string>
-  <string name="manual_update">নিজে থেকে সর্বশেষ সংস্করণ ইনস্টল করার চেষ্টা করুন: https://lantern-android.io</string>
+  <string name="manual_update">নিজে থেকে সর্বশেষ সংস্করণ ইনস্টল করার চেষ্টা করুন: https://github.com/getlantern/lantern</string>
   <string name="pro_welcome_text">Lantern Pro এ আপনাকে স্বগাতম!</string>
   <string name="happy_anniversary">শুভ LANTERN বার্ষিকী!</string>
   <string name="welcome_greeting">Lantern এ আপনাকে স্বগাতম!</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -44,7 +44,7 @@
   <string name="not_now">Ara no</string>
   <string name="install_update">Actualitza</string>
   <string name="error_update">S\'ha produït un error descarregant l\'actualització</string>
-  <string name="manual_update">Proveu d\'instal·lar la darrera versió des d\'<a href="https://lantern-android.io">aquí</a></string>
+  <string name="manual_update">Proveu d\'instal·lar la darrera versió des d\'<a href="https://github.com/getlantern/lantern">aquí</a></string>
   <string name="pro_welcome_text">Benvinguts al Lantern PRO</string>
   <string name="renew_pro_account">Renoveu el compte Pro</string>
   <string name="change_phone_number">Canvieu el número de telèfon</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -78,7 +78,7 @@
   <string name="install_update">Aktualisieren</string>
   <string name="error_update">Fehler beim Herunterladen der Aktualisierung</string>
   <string name="loading">Ladevorgang..</string>
-  <string name="manual_update">Versuchen Sie die neueste Version von &lt;a href=\"https://lantern-android.io\"&gt;hier1&lt;/a&gt; manuell zu installieren</string>
+  <string name="manual_update">Versuchen Sie die neueste Version von &lt;a href=\"https://github.com/getlantern/lantern\"&gt;hier&lt;/a&gt; manuell zu installieren</string>
   <string name="pro_welcome_text">Willkommen bei Lantern Pro!</string>
   <string name="lantern_pro_radio">Lantern Pro - Unbegrenzt Daten</string>
   <string name="lantern_free_radio">Lantern Basic - 500 MB Daten</string>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -91,7 +91,7 @@
   <string name="install_update">Ενημέρωση</string>
   <string name="error_update">Παρουσιάστηκε σφάλμα κατά τη λήψη της ενημέρωσης</string>
   <string name="loading">Λήψη..</string>
-  <string name="manual_update">Δοκιμάστε να εγκαταστήσετε χειροκίνητα την πιο πρόσφατη έκδοση από το &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Δοκιμάστε να εγκαταστήσετε χειροκίνητα την πιο πρόσφατη έκδοση από το &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Καλώς ήλθατε στο Lantern Pro!</string>
   <string name="happy_anniversary">ΧΑΡΟΥΜΕΝΗ LANTERN ΕΠΕΤΕΙΟ!</string>
   <string name="welcome_greeting">Καλώς ήλθατε στο Lantern</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">Error al descargar actualización</string>
   <string name="error_install_update">Error al instalar la actualización</string>
   <string name="loading">Cargando...</string>
-  <string name="manual_update">Trate de instalar manualmente la última versión desde &lt;a href=\"https://lantern-android.io\"&gt;aquí1&lt;/a&gt;</string>
+  <string name="manual_update">Trate de instalar manualmente la última versión desde &lt;a href=\"https://github.com/getlantern/lantern\"&gt;aquí&lt;/a&gt;</string>
   <string name="pro_welcome_text">¡Bienvenido a Lantern Pro!</string>
   <string name="happy_anniversary">¡FELIZ ANIVERSARIO DE LANTERN!</string>
   <string name="welcome_greeting">Bienvenido a Lantern</string>

--- a/android/app/src/main/res/values-fa-rIR/strings.xml
+++ b/android/app/src/main/res/values-fa-rIR/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">ایراد در دانلود به روز رسانی</string>
   <string name="error_install_update">خطا در نصب نسخه به‌روز</string>
   <string name="loading">در حال بارگذاری...</string>
-  <string name="manual_update">به صورت دستی آخرین نسخه را از  &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt; دانلود کنید</string>
+  <string name="manual_update">به صورت دستی آخرین نسخه را از  &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt; دانلود کنید</string>
   <string name="pro_welcome_text">به  فانوس Pro خوش آمدید!</string>
   <string name="happy_anniversary">سالگرد فانوس مبارک!</string>
   <string name="welcome_greeting">به  فانوس خوش آمدید</string>

--- a/android/app/src/main/res/values-fil/strings.xml
+++ b/android/app/src/main/res/values-fil/strings.xml
@@ -90,7 +90,7 @@
   <string name="install_update">Update</string>
   <string name="error_update">Nagkaproblema sa Pag-download ng Update</string>
   <string name="loading">Nagloload..</string>
-  <string name="manual_update">Subukan ang manu-manong pag-install ng pinakabagong bersyon &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Subukan ang manu-manong pag-install ng pinakabagong bersyon &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Maligayang Pagdating sa Lantern Pro</string>
   <string name="happy_anniversary">MALIGAYANG ANIBERSARYO SA LANTERN!</string>
   <string name="welcome_greeting">Maligayang Pagdating sa Lantern</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">Erreur de téléchargement de la mise à jour</string>
   <string name="error_install_update">Erreur lors de l\'installation de la mise à jour</string>
   <string name="loading">Chargement…</string>
-  <string name="manual_update">Essayez d’installer manuellement la dernière version sur &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Essayez d’installer manuellement la dernière version sur &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Bienvenue à Lantern Pro !</string>
   <string name="happy_anniversary">JOYEUX ANNIVERSAIRE, LANTERN.</string>
   <string name="welcome_greeting">Bienvenue à Lantern</string>

--- a/android/app/src/main/res/values-hi-rIN/strings.xml
+++ b/android/app/src/main/res/values-hi-rIN/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">अपडेट डाउनलोड करने में त्रुटि</string>
   <string name="error_install_update">अपडेट इंस्टॉल करने में गड़बड़ी</string>
   <string name="loading">लोड हो रहा है..</string>
-  <string name="manual_update">&lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt; से नवीनतम संस्करण को मैन्युअल रूप से इंस्टॉल करने का प्रयास करें</string>
+  <string name="manual_update">&lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt; से नवीनतम संस्करण को मैन्युअल रूप से इंस्टॉल करने का प्रयास करें</string>
   <string name="pro_welcome_text">Lantern Pro में आपका स्वागत है!</string>
   <string name="happy_anniversary">LANTERN के वर्षगाँठ की बधाई!</string>
   <string name="welcome_greeting">Lantern में आपका स्वागत है</string>

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -72,7 +72,7 @@
   <string name="not_now">Nem most</string>
   <string name="install_update">Frissítés</string>
   <string name="error_update">Hiba a frissítés letöltésekor</string>
-  <string name="manual_update">Próbálja meg kézzel telepíteni a legfrssebb verziót innen: &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Próbálja meg kézzel telepíteni a legfrssebb verziót innen: &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Üdvözöljük a Lantern Pro-ban!</string>
   <string name="welcome_to_lantern">Köszöntjük az új és fejlettebb Lantern-ben</string>
   <string name="to_get_unlimited">A korlátlan adatért, a rendkívüli sebességért, és a még erősebb blokkolás állóság érdekében\FRISSÍTSEN Pro előfizetésre!</string>

--- a/android/app/src/main/res/values-id/strings.xml
+++ b/android/app/src/main/res/values-id/strings.xml
@@ -91,7 +91,7 @@
   <string name="install_update">Update</string>
   <string name="error_update">Kesalahan Mendownload Update</string>
   <string name="loading">Memuat..</string>
-  <string name="manual_update">Coba instal secara manual versi terbaru dari &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Coba instal secara manual versi terbaru dari &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Selamat datang di Lantern Pro!</string>
   <string name="happy_anniversary">HAPPY LANTERN ANNIVERSARY!</string>
   <string name="welcome_greeting">Selamat datang di Lantern</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -85,7 +85,7 @@
   <string name="not_now">나중에</string>
   <string name="install_update">업데이트</string>
   <string name="error_update">다운로드 오류</string>
-  <string name="manual_update">&lt;a href=\"https://lantern-android.io\"&gt;이곳1&lt;/a&gt;에서 최신 버전을 수동으로 설치해 주세요.</string>
+  <string name="manual_update">&lt;a href=\"https://github.com/getlantern/lantern\"&gt;이곳&lt;/a&gt;에서 최신 버전을 수동으로 설치해 주세요.</string>
   <string name="pro_welcome_text">랜턴 프로에 오신 것을 환영합니다.</string>
   <string name="welcome_to_lantern">새롭고 개선된 랜턴에 오신 것을 환영합니다.</string>
   <string name="to_get_unlimited">무제한 데이터, 궁극의 속도, 강력한 차단 우회를 위해\n프로로 업그레이드하세요!</string>

--- a/android/app/src/main/res/values-ms/strings.xml
+++ b/android/app/src/main/res/values-ms/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">Ralat Muat Turun Update</string>
   <string name="error_install_update">Ralat Pemasangan Kemas Kini</string>
   <string name="loading">Muat...</string>
-  <string name="manual_update">Cuba memasang versi terkini secara manual dari &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Cuba memasang versi terkini secara manual dari &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Selamat datang ke Lantern Pro!</string>
   <string name="happy_anniversary">SELAMAT ULANG TAHUN LANTERN!</string>
   <string name="welcome_greeting">Selamat datang ke Lantern</string>

--- a/android/app/src/main/res/values-my/strings.xml
+++ b/android/app/src/main/res/values-my/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">အပ်ဒိတ်ကို ဒေါင်းလုပ်ဆွဲယူခြင်းအမှား</string>
   <string name="error_install_update">အပ်ဒိတ် ထည့်သွင်းရာတွင် မှားယွင်းမှု</string>
   <string name="loading">တင်နေသည် ..</string>
-  <string name="manual_update">&lt;a href="https://lantern-android.io"&gt; here1 &lt;/a&gt; မှ နောက်ဆုံးပေါ်ဗားရှင်းကို ကိုယ်တိုင်ကိုယ်ကျထည့်သွင်းရန်ကြိုးစားပါ</string>
+  <string name="manual_update">&lt;a href="https://github.com/getlantern/lantern"&gt; here &lt;/a&gt; မှ နောက်ဆုံးပေါ်ဗားရှင်းကို ကိုယ်တိုင်ကိုယ်ကျထည့်သွင်းရန်ကြိုးစားပါ</string>
   <string name="pro_welcome_text">Lantern Pro မှကြိုဆိုပါသည်။</string>
   <string name="happy_anniversary">ပျော်ရွှင်စရာ LANTERN နှစ်ပတ်လည်</string>
   <string name="welcome_greeting">Lantern မှကြိုဆိုပါတယ်</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -91,7 +91,7 @@
   <string name="install_update">Oppdater</string>
   <string name="error_update">Feil under nedlasting av oppdatering</string>
   <string name="loading">Laster…</string>
-  <string name="manual_update">Prøv å installere siste versjon manuelt fra &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Prøv å installere siste versjon manuelt fra &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Velkommen til Lantern Pro!</string>
   <string name="happy_anniversary">GLEDELIG LANTERN-JUBILEUM!</string>
   <string name="welcome_greeting">Velkommen til Lantern</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -88,7 +88,7 @@
   <string name="install_update">Update</string>
   <string name="error_update">Fout Downloaden Update</string>
   <string name="loading">Bezig met laden...</string>
-  <string name="manual_update">Probeer handmatig de laatste versie te installeren via &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Probeer handmatig de laatste versie te installeren via &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Welkom bij Lantern Pro!</string>
   <string name="welcome_to_lantern">Welkom bij het nieuwe en verbeterde Lantern</string>
   <string name="to_get_unlimited">Om ongelimiteerde data te verkrijgen, hoogste snelheid en zelfs sterkere blokkade resistentie\nUPGRADE naar Pro!</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -91,7 +91,7 @@
   <string name="install_update">Atualizar</string>
   <string name="error_update">Erro ao baixar atualização</string>
   <string name="loading">Carregando...</string>
-  <string name="manual_update">Tente instalar manualmente a última versão &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Tente instalar manualmente a última versão &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Bem vindo ao Lantern Pro!</string>
   <string name="happy_anniversary">FELIZ ANIVERSÁRIO LANTERNA!</string>
   <string name="welcome_greeting">Bem vindo ao Lanterna</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -91,7 +91,7 @@
   <string name="install_update">Atualizar</string>
   <string name="error_update">Erro ao Transferir a Atualização</string>
   <string name="loading">A carregar...</string>
-  <string name="manual_update">Tente instalar manualmente a versão mais recente de &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Tente instalar manualmente a versão mais recente de &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Bem-vindo ao Lantern Pro!</string>
   <string name="happy_anniversary">FELIZ ANIVERSÁRIO LANTERN!</string>
   <string name="welcome_greeting">Bem-vindo ao Lantern</string>

--- a/android/app/src/main/res/values-ru-rRU/strings.xml
+++ b/android/app/src/main/res/values-ru-rRU/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">Ошибка в скачивании обновления</string>
   <string name="error_install_update">Ошибка при установке обновления</string>
   <string name="loading">Загрузка..</string>
-  <string name="manual_update">Попробуйте вручную установить последнюю версию из &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">Попробуйте вручную установить последнюю версию из &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">Добро пожаловать в Lantern Pro!</string>
   <string name="happy_anniversary">С LANTERN ЮБИЛЕЕМ!</string>
   <string name="welcome_greeting">Добро пожаловать в Lantern</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -92,7 +92,7 @@
   <string name="install_update">อัพเดต</string>
   <string name="error_update">เกิดข้อผิดพลาดในการดาวน์โหลดอัพเดต</string>
   <string name="loading">กำลังโหลด...</string>
-  <string name="manual_update">ลองติดตั้งเวอร์ชั่นล่าสุดด้วยตัวเองจาก &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">ลองติดตั้งเวอร์ชั่นล่าสุดด้วยตัวเองจาก &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">ยินดีต้อนรับสู่ Lantern Pro!</string>
   <string name="happy_anniversary">สุขสันต์วันครบรอบ LANTERN</string>
   <string name="welcome_greeting">ยินดีต้อนรับสู่ Lantern</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">Güncelleme İndirilirken Hata Oluştu</string>
   <string name="error_install_update">Güncelleme Kurulurken Hata Oluştu</string>
   <string name="loading">Yükleniyor..</string>
-  <string name="manual_update">Son sürümü &lt;a href=\"https://lantern-android.io\"&gt;buradan1&lt;/a&gt; elle kurmayı deneyin.</string>
+  <string name="manual_update">Son sürümü &lt;a href=\"https://github.com/getlantern/lantern\"&gt;buradan&lt;/a&gt; elle kurmayı deneyin.</string>
   <string name="pro_welcome_text">Lantern Pro\'ya Hoş Geldiniz!</string>
   <string name="happy_anniversary">MUTLU LANTERN YILDÖNÜMÜ!</string>
   <string name="welcome_greeting">Lantern\'e Hoşgeldiniz</string>

--- a/android/app/src/main/res/values-ur/strings.xml
+++ b/android/app/src/main/res/values-ur/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">اَپ ڈیٹ ڈاؤن لوڈ کرنے میں دشواری</string>
   <string name="error_install_update">اپ ڈیٹ انسٹال کرنے میں نقص</string>
   <string name="loading">لوڈ ہو رہا ہے۔۔</string>
-  <string name="manual_update">حالیہ ورژن کو یہاں سے ڈاؤن لوڈ کرنے کی کوشش کیجئے &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">حالیہ ورژن کو یہاں سے ڈاؤن لوڈ کرنے کی کوشش کیجئے &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">لینٹرن پرو میں خوش آمدید!</string>
   <string name="happy_anniversary">لینٹرن سالگرہ مبارک!</string>
   <string name="welcome_greeting">لینٹرن میں خوش آمدید!</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -105,7 +105,7 @@
   <string name="error_update">Có lỗi tải phiên bản cập nhật</string>
   <string name="error_install_update">Lỗi khi cài đặt bản cập nhật</string>
   <string name="loading">Đang nạp...</string>
-  <string name="manual_update">Thử cài đặt bằng tay phiên bản mới nhất từ &lt;a href=\"https://lantern-android.io\"&gt;nơi đây&lt;/a&gt;</string>
+  <string name="manual_update">Thử cài đặt bằng tay phiên bản mới nhất từ &lt;a href=\"https://github.com/getlantern/lantern\"&gt;nơi đây&lt;/a&gt;</string>
   <string name="pro_welcome_text">Chào mừng đến với Lantern Pro!</string>
   <string name="happy_anniversary">CHÚC MỪNG SINH NHẬT LANTERN!</string>
   <string name="welcome_greeting">Xin chào mừng bạn đã đến với Lantern</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -95,7 +95,7 @@
   <string name="error_update">下载更新时出错</string>
   <string name="error_install_update">安装更新时出错</string>
   <string name="loading">正在加载...</string>
-  <string name="manual_update">请尝试从以下网站手动安装最新版本：&lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">请尝试从以下网站手动安装最新版本：&lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">欢迎使用“蓝灯专业版”！</string>
   <string name="happy_anniversary">祝蓝灯周年快乐！</string>
   <string name="welcome_greeting">欢迎来到蓝灯</string>

--- a/android/app/src/main/res/values-zh-rHK/strings.xml
+++ b/android/app/src/main/res/values-zh-rHK/strings.xml
@@ -95,7 +95,7 @@
   <string name="error_update">下載更新錯誤</string>
   <string name="error_install_update">安裝更新時發生錯誤</string>
   <string name="loading">正在載入…</string>
-  <string name="manual_update">嘗試手動安裝最新版本，網址為 &amp;lt;a href="https://lantern-android.io"&amp;gt;here1&amp;lt;/a&amp;gt；</string>
+  <string name="manual_update">嘗試手動安裝最新版本，網址為 &amp;lt;a href="https://github.com/getlantern/lantern"&amp;gt;here&amp;lt;/a&amp;gt；</string>
   <string name="pro_welcome_text">歡迎加入 Lantern Pro！</string>
   <string name="happy_anniversary">LANTERN 周年紀念！</string>
   <string name="welcome_greeting">歡迎來到 Lantern</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -63,7 +63,7 @@
   <string name="not_now">下次</string>
   <string name="install_update">更新</string>
   <string name="error_update">下載更新時錯誤</string>
-  <string name="manual_update">請嘗試從下列網址下載並安裝最新版 &lt;a href=\"https://lantern-android.io\"&gt;here1&lt;/a&gt;</string>
+  <string name="manual_update">請嘗試從下列網址下載並安裝最新版 &lt;a href=\"https://github.com/getlantern/lantern\"&gt;here&lt;/a&gt;</string>
   <string name="pro_welcome_text">歡迎來到 Lantern Pro！</string>
   <string name="renew_pro_account">更新付費專業版帳號</string>
   <string name="logout">登出</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
     <string name="error_update">Error Downloading Update</string>
     <string name="error_install_update">Error Installing Update</string>
     <string name="loading">Loading..</string>
-    <string name="manual_update">Try manually installing the latest version from &lt;a href="https://lantern-android.io">here1&lt;/a></string>
+    <string name="manual_update">Try manually installing the latest version from &lt;a href="https://github.com/getlantern/lantern"&gt;here&lt;/a&gt;</string>
     <string name="pro_welcome_text">Welcome to Lantern Pro!</string>
     <string name="happy_anniversary">HAPPY LANTERN ANNIVERSARY!</string>
     <string name="welcome_greeting">Welcome to Lantern</string>

--- a/android/app/src/sideload/java/org/getlantern/lantern/activity/UpdateActivity.java
+++ b/android/app/src/sideload/java/org/getlantern/lantern/activity/UpdateActivity.java
@@ -11,6 +11,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.text.Html;
 import android.view.WindowManager;
 import android.widget.TextView;
 
@@ -238,7 +239,7 @@ public class UpdateActivity extends Activity implements ActivityCompat.OnRequest
             Utils.showAlertDialog(
                     activity,
                     context.getString(R.string.error_install_update),
-                    context.getString(R.string.manual_update),
+                    manualUpdateHTML(),
                     true);
         }
 
@@ -269,14 +270,14 @@ public class UpdateActivity extends Activity implements ActivityCompat.OnRequest
 
             if (!result) {
                 Logger.debug(TAG, "Error trying to install Lantern update");
-                Utils.showAlertDialog(this.activity, context.getString(R.string.error_update), context.getString(R.string.manual_update), false);
+                Utils.showAlertDialog(this.activity, context.getString(R.string.error_update), manualUpdateHTML(), false);
                 return;
             }
 
             Logger.debug(TAG, "About to install new version of Lantern Android");
             if (!apkPath.isFile()) {
                 Logger.error(TAG, "Error loading APK; not found at " + apkPath);
-                Utils.showAlertDialog(this.activity, context.getString(R.string.error_update), context.getString(R.string.manual_update), false);
+                Utils.showAlertDialog(this.activity, context.getString(R.string.error_update), manualUpdateHTML(), false);
                 return;
             }
             try {
@@ -303,6 +304,10 @@ public class UpdateActivity extends Activity implements ActivityCompat.OnRequest
             i.setDataAndType(apkURI, "application/vnd.android.package-archive");
             this.context.startActivity(i);
             activity.finish();
+        }
+
+        private CharSequence manualUpdateHTML() {
+            return Html.fromHtml("<span>" + context.getString(R.string.manual_update) + "</span>");
         }
     }
 }

--- a/internalsdk/android_test.go
+++ b/internalsdk/android_test.go
@@ -240,8 +240,7 @@ func TestInternalHeaders(t *testing.T) {
 
 // This test requires the tag "lantern" to be set at testing time like:
 //
-//    go test -tags="lantern"
-//
+//	go test -tags="lantern"
 func TestAutoUpdate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skip test in short mode")


### PR DESCRIPTION
… link to the correct website, formatted as a link and make link actually clickable

Prior to this change, the displayed alert dialog wasn't actually formatted as HTML, the link pointed to the wrong URL, the link text was "here1" instead of "here" and the link wasn't clickable. This fixes all that.