### PR TITLE
Don't attempt to reconnect when we receive onBillingServiceDisconnected

### DIFF
--- a/android/app/src/main/java/org/getlantern/lantern/model/InAppBilling.java
+++ b/android/app/src/main/java/org/getlantern/lantern/model/InAppBilling.java
@@ -72,6 +72,7 @@ public class InAppBilling implements PurchasesUpdatedListener, BillingClientStat
 
     @Override
     public void onBillingSetupFinished(BillingResult billingResult) {
+        Logger.debug(TAG, "onBillingSetupFinished with response code: " + billingResult.getResponseCode());
         if (billingResult.getResponseCode() != BillingClient.BillingResponseCode.OK) {
             if (isRetriable(billingResult)) {
                 handler.postDelayed(() -> {
@@ -88,9 +89,7 @@ public class InAppBilling implements PurchasesUpdatedListener, BillingClientStat
 
     @Override
     public void onBillingServiceDisconnected() {
-        // Try to restart the connection on the next request to
-        // Google Play by calling the startConnection() method.
-        startConnection();
+        Logger.debug(TAG, "onBillingServiceDisconnected");
     }
 
     /**


### PR DESCRIPTION
For getlantern/engineering#66, getlantern/engineering#67 and getlantern/engineering#68

According to [the documentation](https://developer.android.com/reference/com/android/billingclient/api/BillingClientStateListener#onBillingServiceDisconnected()), it looks like we don't actually need to try to rebind because we remain bound. Whenever the billing service is connected again, it should hit our `onBillingSetupFinished` method.