### PR TITLE
Use ListView to make settings screen scrollable

### DIFF
--- a/lib/account/settings.dart
+++ b/lib/account/settings.dart
@@ -31,7 +31,9 @@ class Settings extends StatelessWidget {
   Widget build(BuildContext context) {
     return BaseScreen(
       title: 'settings'.i18n,
-      body: Column(
+      padVertical: true,
+      body: ListView(
+        shrinkWrap: true,
         children: [
           //* Language
           ListItemFactory.settingsItem(


### PR DESCRIPTION
This PR updates the settings screen to be scrollable by using a ListView instead of a Column (similar to developer settings).

I didn't see the overflow issue on my device (Samsung Galaxy S9) but I tested adding some additional items to confirm it scrolls now