### PR TITLE
Change description on Invite Friends page

### DIFF
--- a/android/app/src/main/java/org/getlantern/lantern/activity/InviteActivity.java
+++ b/android/app/src/main/java/org/getlantern/lantern/activity/InviteActivity.java
@@ -44,9 +44,6 @@ public class InviteActivity extends BaseFragmentActivity {
     @ViewById
     View bgText;
 
-    @ViewById
-    TextView tvShare;
-
     private Handler handlerCopyAnim;
 
     @AfterViews
@@ -55,11 +52,6 @@ public class InviteActivity extends BaseFragmentActivity {
         bgText.setAlpha(0f);
         resources = getResources();
         progressFragment = ProgressDialogFragment.newInstance(R.string.progressMessage2);
-        if (LanternApp.getSession().isProUser()) {
-            tvShare.setText(getString(R.string.referral_code_share_description_pro));
-        } else {
-            tvShare.setText(getString(R.string.referral_code_share_description_free));
-        }
     }
 
     @Override

--- a/android/app/src/main/res/layout/invite_friends.xml
+++ b/android/app/src/main/res/layout/invite_friends.xml
@@ -112,7 +112,7 @@
         android:id="@+id/tvShare"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/referral_code_share_description_pro"
+        android:text="@string/referral_code_share_description"
         android:layout_marginHorizontal="@dimen/space_large"
         android:layout_marginTop="@dimen/space_large"
         android:textAppearance="?attr/textAppearanceBody2"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -423,8 +423,7 @@
     <string name="privacy_disclosure_title">Lantern Privacy Disclosure</string>
     <string name="privacy_disclosure_accept">I Accept</string>
     <string name="privacy_disclosure_body">Lantern is committed to protecting your privacy. We want you to understand what information we collect, what we don’t collect, and how we collect, use, and store information. We disassociate your payment information with your Lantern Pro account. We do not collect logs of your activity, including no logging of browsing history, traffic destination, data content, or DNS queries. We also never store connection logs, meaning no logs of your IP address, your outgoing Lantern server IP address associated with the connection timestamp, or session duration. Given a specific Lantern Pro account, Lantern is technically unable to associate the Lantern account with the real identity of the user. Given a Lantern IP address and a precise time-stamp, Lantern is technically unable to attribute this IP address to a Lantern user or a Lantern user IP address.</string>
-    <string name="referral_code_share_description_free">Share your code with your friends and get one month of Lantern Pro service for free when they purchase Pro!</string>
-    <string name="referral_code_share_description_pro">Share your code with your friends and get one month of additional Lantern Pro service for free when they purchase Pro!</string>
+    <string name="referral_code_share_description">Share Lantern Pro with a friend! When your friend uses your referral code during their purchase of Lantern Pro, you will both receive one month of Lantern Pro service for free!</string>
     <string name="referral_code_share">Share referral code</string>
     <string name="referral_code_share_title">Share your Referral code:</string>
     <string name="lantern_desktop_link">https://github.com/getlantern/lantern</string>


### PR DESCRIPTION
For getlantern/engineering#113

This now uses the same text whether you're currently free or pro.

Here's how it looks

<img width="434" alt="image" src="https://github.com/getlantern/android-lantern/assets/5000654/719b65f9-7bc9-4e6e-81a5-4a4a880fc773">
