### PR TITLE
Revert "Use fully qualified class name for notification receiver registered in Android manifest"

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
 
         <receiver android:name = ".model.DeclineCallBroadcastReceiver" />
 
-        <receiver android:name="org.getlantern.lantern.notification.NotificationReceiver" android:exported="true">
+        <receiver android:name=".notification.NotificationReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="org.getlantern.lantern.intent.VPN_DISCONNECTED"/>
             </intent-filter>


### PR DESCRIPTION
Reverts getlantern/android-lantern#848