### PR TITLE
Initialize connection to Google for in-app billing in startPurchase

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/model/InAppBilling.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/model/InAppBilling.kt
@@ -69,7 +69,6 @@ class InAppBilling(
                             handlePendingPurchases()
                             return
                         }
-                        isRetriable(billingResult)
                         endConnection()
                     }
                     override fun onBillingServiceDisconnected() =


### PR DESCRIPTION
~Fix for org.getlantern.lantern.model.InAppBilling.startConnection [crash](https://play.google.com/console/u/0/developers/4642290275832863621/app/4973965144252805146/vitals/crashes/6426a0ef6f1c8e3d92e700b70294e711/details)~