### PR TITLE
Fix errors detected by fdscan to improve user-perceived crash rate

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/vpn/GoTun2SocksProvider.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/vpn/GoTun2SocksProvider.kt
@@ -101,7 +101,7 @@ class GoTun2SocksProvider(
             Logger.debug(TAG, "Creating VpnBuilder before starting tun2socks")
             val intf = createBuilder(vpnService, builder)
             val tunFd = intf?.detachFd()
-            if (intf != null) {
+            if (tunFd != null) {
                 Logger.debug(TAG, "Running tun2socks")
                 Internalsdk.tun2Socks(
                     tunFd.toLong(),


### PR DESCRIPTION
For https://github.com/getlantern/engineering/issues/201

[fdsan](https://android.googlesource.com/platform/bionic/+/master/docs/fdsan.md) is a file descriptor sanitizer added to Android in API level 29. It detects mishandling of file descriptor ownership, which tends to manifest as use-after-close and double-close errors.

- fdsan: double-close of file descriptor 191 detected crash: https://play.google.com/console/u/0/developers/4642290275832863621/app/4973965144252805146/vitals/crashes/a7eece6f043a8d57138a113a1e61c2f3/details?versionCode=438168204

In the GoTun2SocksProvider class, we use VpnService.Builder.establish() to create the TUN device and return a file descriptor the application uses to access IP packets on it. tun2socks takes ownership of this file descriptor and closes it whenever ipproxy is stopped.

However, whenever the VPN is turned off, we are also calling ParcelFileDescriptor.close(). Given the fd is already closed, fdscan complains that we're double closing it. By calling `detachFd` instead of `getFd`, we can detach the file descriptor from the ParcelFileDescriptor object