### PR TITLE
Stop using JSON across Go/Swift boundary and use pathdb's built-in support for protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/getlantern/idletiming v0.0.0-20201229174729-33d04d220c4e
 	github.com/getlantern/ipproxy v0.0.0-20230511223023-ee52513fd782
 	github.com/getlantern/mtime v0.0.0-20200417132445-23682092d1f7
-	github.com/getlantern/pathdb v0.0.0-20231005134844-d5ef1ce95949
+	github.com/getlantern/pathdb v0.0.0-20231011022612-e0fb1003dce8
 	github.com/getlantern/replica v0.14.1
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/getlantern/osversion v0.0.0-20230401075644-c2a30e73c451 h1:3Nn0AqIlIm
 github.com/getlantern/osversion v0.0.0-20230401075644-c2a30e73c451/go.mod h1:kaUdXyKE1Y8bwPnlN7ChFXWnkADpL0zZrk8F0XbpKcc=
 github.com/getlantern/packetforward v0.0.0-20201001150407-c68a447b0360 h1:pijUoofaQcAM/8zbDzZM2LQ90kGVbKfnSAkFnQwLZZU=
 github.com/getlantern/packetforward v0.0.0-20201001150407-c68a447b0360/go.mod h1:nsJPNYUSY96xB+p7uiDW8O4uiKea+KjeUdS5d6tf9IU=
-github.com/getlantern/pathdb v0.0.0-20231005134844-d5ef1ce95949 h1:eeBSC1sYMtEcSq7gYnNtKfvAyFxQ8aWk26Sd6ZdC7qE=
-github.com/getlantern/pathdb v0.0.0-20231005134844-d5ef1ce95949/go.mod h1:SFQy+f58IbLpnbq2nVqlq7ccwaUiO7ablKv631WVIuc=
+github.com/getlantern/pathdb v0.0.0-20231011022612-e0fb1003dce8 h1:dw8BlhZotSe57aoDrtlluDBmO9fCptEzu4YZ8ItHq1o=
+github.com/getlantern/pathdb v0.0.0-20231011022612-e0fb1003dce8/go.mod h1:SFQy+f58IbLpnbq2nVqlq7ccwaUiO7ablKv631WVIuc=
 github.com/getlantern/preconn v0.0.0-20180328114929-0b5766010efe/go.mod h1:FvIxQD61iYA42UjaJyzGl9DNne8jbowbgicdeNk/7kE=
 github.com/getlantern/preconn v1.0.0 h1:DsY3l/y/BJUj86WyaxXylbJnCC9QbKcc3D6js6rFL60=
 github.com/getlantern/preconn v1.0.0/go.mod h1:i/AnXvx715Fq7HgZLlmQlw3sGfEkku8BQT5hLHMK4+k=

--- a/ios/Runner/Lantern/Core/Db/SubscriberRequest.swift
+++ b/ios/Runner/Lantern/Core/Db/SubscriberRequest.swift
@@ -31,123 +31,26 @@ class DetailsSubscriber: InternalsdkSubscriptionRequest {
 
 class DetailsSubscriberUpdater: NSObject, InternalsdkUpdaterModelProtocol {
   var onChangesCallback: (([String: Any], [String]) -> Void)?
-  typealias DynamicKeysData = [String: ItemDetail]
 
-  func onChanges(_ cs: InternalsdkChangeSetInterface?) throws {
+  func onChanges(_ cs: InternalsdkChangeSet?) throws {
     guard let cs = cs else {
       throw NSError(
         domain: "onChangesError", code: 1, userInfo: [NSLocalizedDescriptionKey: "ChangeSet is nil"]
       )
     }
-    let decoder = JSONDecoder()
     var updatesDictionary: [String: Any] = [:]
     var deletesList: [String] = []
 
     // Deserialize updates
-    if let updatesData = cs.updatesSerialized.data(using: .utf8), !updatesData.isEmpty {
-      do {
-        let updates = try decoder.decode(DynamicKeysData.self, from: updatesData)
-
-        updatesDictionary = Dictionary(
-          uniqueKeysWithValues: updates.map { (path, detail) -> (String, Any) in
-            return (path, detail.value.value)
-          })
-
-      } catch let jsonError {
-        logger.log("Error deserializing updates: \(jsonError.localizedDescription)")
-        throw jsonError
-      }
-    } else {
-      logger.log("No updatesSerialized data to parse or it's empty.")
+    while cs.hasUpdate() {
+      let update = try cs.popUpdate()
+        updatesDictionary[update.path] = ValueUtil.convertFromMinisqlValue(from:update.value!)
     }
 
-    // Deserialize deletes
-    if cs.deletesSerialized.lowercased() != "null" {
-      if let deletesData = cs.deletesSerialized.data(using: .utf8), !deletesData.isEmpty {
-        do {
-
-          deletesList = try decoder.decode([String].self, from: deletesData)
-        } catch let jsonError {
-          logger.log("Error deserializing deletes: \(jsonError.localizedDescription)")
-          throw jsonError
-        }
-      } else {
-        logger.log("No deletesSerialized data to parse or it's empty.")
-      }
+    while cs.hasDelete() {
+      deletesList.append(cs.popDelete())
     }
 
     onChangesCallback?(updatesDictionary, deletesList)
-
-  }
-}
-
-// Json Decode
-
-struct ItemDetail: Codable {
-  let path: String
-  let detailPath: String
-  let value: ValueStruct
-
-  enum CodingKeys: String, CodingKey {
-    case path = "Path"
-    case detailPath = "DetailPath"
-    case value = "Value"
-  }
-}
-
-struct ValueStruct: Codable {
-  let type: Int
-  var value: Any?
-
-  init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    type = try container.decode(Int.self, forKey: .type)
-
-    switch type {
-    case ValueUtil.TYPE_BYTES:  // Assuming this corresponds to bytes
-      // Handle bytes
-      let stringValue = try container.decode(String.self, forKey: .value)
-      value = Data(base64Encoded: stringValue)
-    case ValueUtil.TYPE_STRING:
-      value = try container.decode(String.self, forKey: .value)
-    case ValueUtil.TYPE_INT:
-      value = try container.decode(Int.self, forKey: .value)
-    case ValueUtil.TYPE_BOOL:
-      value = try container.decode(Bool.self, forKey: .value)
-    default:
-      throw DecodingError.dataCorruptedError(
-        forKey: .value,
-        in: container,
-        debugDescription: "Invalid type"
-      )
-    }
-  }
-
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(type, forKey: .type)
-
-    switch type {
-    case ValueUtil.TYPE_BYTES:
-      // Handle bytes
-      if let dataValue = value as? Data {
-        try container.encode(dataValue.base64EncodedString(), forKey: .value)
-      }
-    case ValueUtil.TYPE_STRING:
-      try container.encode(value as? String, forKey: .value)
-    case ValueUtil.TYPE_INT:
-      try container.encode(value as? Int, forKey: .value)
-    case ValueUtil.TYPE_BOOL:
-      try container.encode(value as? Bool, forKey: .value)
-    default:
-      throw EncodingError.invalidValue(
-        value as Any,
-        EncodingError.Context(codingPath: [CodingKeys.value], debugDescription: "Invalid type"))
-    }
-  }
-
-  enum CodingKeys: String, CodingKey {
-    case type = "Type"
-    case value = "Value"
   }
 }


### PR DESCRIPTION
I noticed that we were using JSON to send subscription results from Go to Swift. In addition to having some overhead, this also complicated the code a bit. This PR removes JSON in favor of just using Go objects that can be bound with gomobile.

The other change that this makes is to rely on pathdb's built-in support for protocol buffers. That built-in support wasn't complete, so I made some updates to pathdb, notably the `Raw.ValueOrProtoBytes()` method. Going forward, when we want to store new protobuf types in the database, we just need to register them like this

```
base.db.RegisterType(1000, &ServerInfo{})
```

You'll notice that the existing Android application follows this same pattern with `db-android`.

Saved 154 lines of code too :)