### PR TITLE
fix navigation issue

### DIFF
--- a/internalsdk/session_model.go
+++ b/internalsdk/session_model.go
@@ -316,21 +316,25 @@ func (m *SessionModel) UpdateAdSettings(adsetting AdSettings) error {
 
 // Note - the names of these parameters have to match what's defined on the `Session` interface
 func (m *SessionModel) UpdateStats(serverCity string, serverCountry string, serverCountryCode string, p3 int, p4 int, hasSucceedingProxy bool) error {
-	serverInfo := &protos.ServerInfo{
-		City:        serverCity,
-		Country:     serverCountry,
-		CountryCode: serverCountryCode,
-	}
 
-	return pathdb.Mutate(m.db, func(tx pathdb.TX) error {
-		return pathdb.PutAll(tx, map[string]interface{}{
-			pathServerCountry:      serverCountry,
-			pathServerCity:         serverCity,
-			pathServerCountryCode:  serverCountryCode,
-			pathHasSucceedingProxy: hasSucceedingProxy,
-			pathServerInfo:         serverInfo,
+	if serverCity != "" && serverCountry != "" && serverCountryCode != "" {
+		serverInfo := &protos.ServerInfo{
+			City:        serverCity,
+			Country:     serverCountry,
+			CountryCode: serverCountryCode,
+		}
+
+		return pathdb.Mutate(m.db, func(tx pathdb.TX) error {
+			return pathdb.PutAll(tx, map[string]interface{}{
+				pathServerCountry:      serverCountry,
+				pathServerCity:         serverCity,
+				pathServerCountryCode:  serverCountryCode,
+				pathHasSucceedingProxy: hasSucceedingProxy,
+				pathServerInfo:         serverInfo,
+			})
 		})
-	})
+	}
+	return nil
 }
 
 func (m *SessionModel) SetStaging(staging bool) error {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -57,7 +57,7 @@ class LanternApp extends StatelessWidget {
   void toggleConnectivityWarningIfNecessary() {
     final shouldShowConnectivityWarning =
         !sessionModel.networkAvailable.value ||
-            sessionModel.proxyAvailable.value != true;
+            !(sessionModel.proxyAvailable.value ?? false);
     if (shouldShowConnectivityWarning != showConnectivityWarning) {
       showConnectivityWarning = shouldShowConnectivityWarning;
       if (showConnectivityWarning) {
@@ -65,6 +65,7 @@ class LanternApp extends StatelessWidget {
       } else {
         networkWarningAnimationController.reverse();
       }
+      // Update the state after running the animations.
     }
   }
 
@@ -85,11 +86,10 @@ class LanternApp extends StatelessWidget {
               overlayColor: Colors.black,
               overlayOpacity: 0.6,
               child: I18n(
-                initialLocale:currentLocale(lang),
+                initialLocale: currentLocale(lang),
                 child: MaterialApp.router(
                   locale: currentLocale(lang),
                   debugShowCheckedModeBanner: false,
-
                   theme: ThemeData(
                     fontFamily: _getLocaleBasedFont(currentLocal),
                     brightness: Brightness.light,
@@ -100,7 +100,6 @@ class LanternApp extends StatelessWidget {
                     colorScheme: ColorScheme.fromSwatch()
                         .copyWith(secondary: Colors.black),
                   ),
-
                   title: 'app_name'.i18n,
                   localizationsDelegates: const [
                     GlobalMaterialLocalizations.delegate,
@@ -138,9 +137,8 @@ class LanternApp extends StatelessWidget {
     if (lang == '' || lang.startsWith('en')) {
       return const Locale('en', 'US');
     }
-    final codes =  lang.split('_');
+    final codes = lang.split('_');
     return Locale(codes[0], codes[1]);
-
   }
 
   String _getLocaleBasedFont(Locale locale) {

--- a/lib/common/ui/base_screen.dart
+++ b/lib/common/ui/base_screen.dart
@@ -67,36 +67,35 @@ class BaseScreen extends StatelessWidget {
         appBar: !showAppBar
             ? null
             : PreferredSize(
-                preferredSize: Size.fromHeight(appBarHeight),
-                child: Transform.translate(
-                  offset: Offset(0.0, verticalCorrection),
-                  child: Stack(
-                    fit: StackFit.passthrough,
-                    alignment: AlignmentDirectional.topCenter,
-                    children: [
-                      AppBar(
-                        automaticallyImplyLeading: automaticallyImplyLeading,
-                        title: title is String
-                            ? CText(
-                                title,
-                                style: tsHeading3
-                                    .copiedWith(color: foregroundColor)
-                                    .short,
-                              )
-                            : title,
-                        elevation: 1,
-                        shadowColor: grey3,
-                        foregroundColor: foregroundColor,
-                        backgroundColor: backgroundColor,
-                        iconTheme: IconThemeData(color: foregroundColor),
-                        centerTitle: centerTitle,
-                        titleSpacing: 0,
-                        actions: actions,
-                      ),
-                      ConnectivityWarning(
-                        dy: verticalCorrection,
-                      ),
-                    ],
+                preferredSize: Size.fromHeight(appBarHeight+verticalCorrection),
+                child: SafeArea(
+                  child: Column(
+                      children: [
+                        ConnectivityWarning(
+                          dy: verticalCorrection,
+                        ),
+                        AppBar(
+                          automaticallyImplyLeading: automaticallyImplyLeading,
+                          title: title is String
+                              ? CText(
+                                  title,
+                                  style: tsHeading3
+                                      .copiedWith(color: foregroundColor)
+                                      .short,
+                                )
+                              : title,
+                          elevation: 1,
+                          shadowColor: grey3,
+                          foregroundColor: foregroundColor,
+                          backgroundColor: backgroundColor,
+                          iconTheme: IconThemeData(color: foregroundColor),
+                          centerTitle: centerTitle,
+                          titleSpacing: 0,
+                          actions: actions,
+                        ),
+
+                      ],
+
                   ),
                 ),
               ),
@@ -104,7 +103,7 @@ class BaseScreen extends StatelessWidget {
           padding: EdgeInsetsDirectional.only(
             start: padHorizontal ? 16 : 0,
             end: padHorizontal ? 16 : 0,
-            top: padVertical ? 16 + verticalCorrection : verticalCorrection,
+            top: padVertical ? 16:0,
             bottom: padVertical ? 16 : 0,
           ),
           child: body,
@@ -142,12 +141,14 @@ class ConnectivityWarning extends StatelessWidget {
                 description: 'connection_error_des'.i18n,
                 agreeText: 'connection_error_button'.i18n,
                 agreeAction: () async {
+                  context.popRoute();
                   await context.pushRoute(ReportIssue());
                   return true;
                 },
               ).show(context)
           : null,
-      child: Container(
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 600),
         width: MediaQuery.of(context).size.width,
         color: yellow6,
         height: dy,


### PR DESCRIPTION
This PR fixes the issue on navigation while ConnectivityWarning is on.

The problem

We applied the 'Transform' widget to shift the appearance of buttons on the AppBar, making them look relocated. However, their actual 'clickable' zones didn't move with them. This caused confusion — users clicked where they saw the buttons, but nothing happened because the real, responsive part of the button hadn't moved and was hidden behind a warning message displayed in its place.