### PR TITLE
Update activate protoc-gen-dart step in Android CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Publish releases
 
 on:
   push:
-    branches: [ atavism/protoc-gen-dart-step ]
+    branches: [ main ]
     tags:
       - '*'
 


### PR DESCRIPTION
A fix for Android CI.. we shouldn't have to copy protoc-gen-dart to `~/.pub-cache/bin`

```
Run echo "${HOME}/.pub-cache/bin" >> $GITHUB_PATH
Resolving dependencies...
+ collection 1.18.0
+ fixnum 1.1.0
+ meta 1.12.0
+ path 1.9.0
+ protobuf 3.1.0
+ protoc_plugin [21](https://github.com/getlantern/lantern-client/actions/runs/8161219678/job/22309513083#step:13:22).1.2
Building package executables...
Built protoc_plugin:protoc_plugin.
Built protoc_plugin:protoc_plugin_bazel.
Installed executable protoc-gen-dart.
Activated protoc_plugin 21.1.2.
mv: /Users/runner/hostedtoolcache/flutter/stable-3.19.2-arm64/.pub-cache/bin/protoc-gen-dart: No such file or directory
```