### PR TITLE
Updates to Linux release process

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -103,7 +103,8 @@ jobs:
           ls build/linux
           cp liblantern.so "build/linux/${{inputs.update-suffix}}/release/bundle"
           dart pub global activate flutter_distributor
-          flutter_distributor release --name=dev --jobs=release-dev-linux-deb
+          flutter_distributor release --name=prod --jobs=release-prod-linux-deb
+          cp build/1.0.0+1/lantern-1.0.0+1-linux.deb "lantern_${{inputs.version}}_${{inputs.arch}}.deb"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -127,7 +128,6 @@ jobs:
           mv ${{ env.update_source }} ${{ env.update }}
 
           shasum -a 256 ${{ env.dist }} | cut -d " " -f 1 > ${{ env.dist }}.sha256
-          shasum -a 256 ${{ env.update }} | cut -d " " -f 1 > ${{ env.update }}.sha256
           ls -l
 
-          s3cmd put --acl-public ${{ env.dist }} ${{ env.update }} ${{ env.update }}.sha256 ${{ env.dist }}.sha256 "s3://lantern"
+          s3cmd put --acl-public ${{ env.dist }} ${{ env.dist }}.sha256 "s3://lantern"

--- a/distribute_options.yaml
+++ b/distribute_options.yaml
@@ -1,8 +1,8 @@
 output: build/
 releases:
-  - name: dev
+  - name: prod
     jobs:
-      - name: release-dev-linux-deb
+      - name: release-prod-linux-deb
         package:
           platform: linux
           target: deb


### PR DESCRIPTION
- Use setup-ruby GitHub action instead of installing ruby with apt
- Run `make package-linux-amd64` in release workflow
- Do not copy beta builds to versionless links in S3 release bucket