### PR TITLE
Set language returned by session model on mobile

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -119,10 +119,7 @@ class _LanternAppState extends State<LanternApp> {
         }
         return sessionModel.language(
           (context, lang, child) {
-            if (isDesktop()) {
-              Localization.locale = lang;
-            }
-
+            Localization.locale = lang;
             return GlobalLoaderOverlay(
               overlayColor: Colors.black,
               overlayOpacity: 0.6,


### PR DESCRIPTION
Resolves https://github.com/getlantern/engineering/issues/1248

Not sure why we are only setting the language on desktop