### PR TITLE
Android AGP 8.0 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,11 +155,11 @@ jobs:
           organization: getlantern
           project: android
 
-      - name: Setup JDK 11
-        uses: actions/setup-java@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Generate ffi bindings
         run: |


### PR DESCRIPTION
- Upgrade project to use Android Gradle plugin 8.0
- Fix 'namespace not specified' error that prevented us from upgrading before: https://github.com/getlantern/lantern-client/pull/952
- Remove legacy, imperative apply of Flutter's Gradle plugins/apply with declarative plugins {} block: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
- Enable R8 Code Shrinker