### PR TITLE
Remove use of s3-actions, use pip to install s3cmd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,13 +208,18 @@ jobs:
           path: |
             lantern-installer.aab
 
-      - name: Setup S3cmd cli tool
-        uses: s3-actions/s3cmd@v1.4.0
+      - uses: actions/setup-python@v5
         with:
-          provider: aws
-          region: ${{ secrets.AWS_REGION }}
-          access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          secret_key: ${{ secrets.AWS_SECRET_KEY }}
+          python-version: '3.12'
+
+      - name: Install s3cmd
+        run: pip install s3cmd
+
+      - name: Set s3cmd permissions
+        run: |
+          echo "[default]" > "$HOME/.s3cfg"
+          echo "access_key = ${{ secrets.AWS_ACCESS_KEY }}" >> "$HOME/.s3cfg"
+          echo "secret_key = ${{ secrets.AWS_SECRET_KEY }}" >> "$HOME/.s3cfg"
 
       - name: Push binaries to s3
         env:


### PR DESCRIPTION
Using `s3-actions/s3cmd` breaks CI:

```
Run s3-actions/s3cmd@v1.4.0
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-brew-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.
    
    If you wish to install a non-brew packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
```  

 https://github.com/getlantern/lantern-client/actions/runs/8612860713/job/23602954471#step:20:1
 
 This updates the release workflow to install s3cmd with pip instead.