### PR TITLE
Update ffiPaymentRedirect to use compute

### DIFF
--- a/desktop/lib.go
+++ b/desktop/lib.go
@@ -394,7 +394,7 @@ func deviceLinkingCode() *C.char {
 }
 
 //export paymentRedirect
-func paymentRedirect(planID, currency, provider, email, deviceName *C.char) (*C.char, *C.char) {
+func paymentRedirect(planID, currency, provider, email, deviceName *C.char) *C.char {
 	country := a.Settings().GetCountry()
 	resp, err := proClient.PaymentRedirect(userConfig(), &client.PaymentRedirectRequest{
 		Plan:        C.GoString(planID),
@@ -405,9 +405,9 @@ func paymentRedirect(planID, currency, provider, email, deviceName *C.char) (*C.
 		CountryCode: country,
 	})
 	if err != nil {
-		return nil, sendError(err)
+		return sendError(err)
 	}
-	return C.CString(resp.Redirect), nil
+	return sendJson(resp)
 }
 
 //export developmentMode

--- a/lib/common/session_model.dart
+++ b/lib/common/session_model.dart
@@ -710,13 +710,8 @@ class SessionModel extends Model {
     String provider,
     String deviceName,
   ) async {
-    final resp = ffiPaymentRedirect(
-        planID.toNativeUtf8(),
-        currency.toNativeUtf8(),
-        provider.toNativeUtf8(),
-        email.toNativeUtf8(),
-        deviceName.toNativeUtf8());
-    return resp;
+    return await compute(
+        ffiPaymentRedirect, [planID, currency, provider, email, deviceName]);
   }
 
   Future<void> submitStripePayment(

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -54,7 +54,10 @@ void checkAPIError(result, errorMessage) {
 }
 
 Future<String> ffiApproveDevice(String code) async {
-  final json = await _bindings.approveDevice(code.toPointerChar()).cast<Utf8>().toDartString();
+  final json = await _bindings
+      .approveDevice(code.toPointerChar())
+      .cast<Utf8>()
+      .toDartString();
   final result = APIResponse.create()..mergeFromProto3Json(jsonDecode(json));
   checkAPIError(result, 'wrong_device_linking_code'.i18n);
   // refresh user data after successfully linking device
@@ -63,7 +66,10 @@ Future<String> ffiApproveDevice(String code) async {
 }
 
 Future<void> ffiRemoveDevice(String deviceId) async {
-  final json = await _bindings.removeDevice(deviceId.toPointerChar()).cast<Utf8>().toDartString();
+  final json = await _bindings
+      .removeDevice(deviceId.toPointerChar())
+      .cast<Utf8>()
+      .toDartString();
   final result = LinkResponse.create()..mergeFromProto3Json(jsonDecode(json));
   checkAPIError(result, 'cannot_remove_device'.i18n);
   // refresh user data after removing a device
@@ -80,8 +86,10 @@ Pointer<Utf8> ffiAcceptedTermsVersion() =>
 
 Pointer<Utf8> ffiEmailAddress() => _bindings.emailAddress().cast<Utf8>();
 
-Pointer<Utf8> ffiEmailExists(String email) =>
-    _bindings.emailExists(email.toPointerChar()).cast<Utf8>();
+Future<String> ffiEmailExists(String email) async => await _bindings
+    .emailExists(email.toPointerChar())
+    .cast<Utf8>()
+    .toDartString();
 
 Pointer<Utf8> ffiRedeemResellerCode(email, currency, deviceName, resellerCode) {
   final result =
@@ -130,7 +138,8 @@ Future<void> ffiReportIssue(List<String> list) {
   final email = list[0].toNativeUtf8();
   final issueType = list[1].toNativeUtf8();
   final description = list[2].toNativeUtf8();
-  final result = _bindings.reportIssue(email as Pointer<Char>, issueType as Pointer<Char>, description as Pointer<Char>);
+  final result = _bindings.reportIssue(email as Pointer<Char>,
+      issueType as Pointer<Char>, description as Pointer<Char>);
   if (result.r1 != nullptr) {
     // Got error throw error to show error ui state
     final errorCode = result.r1.cast<Utf8>().toDartString();
@@ -140,18 +149,20 @@ Future<void> ffiReportIssue(List<String> list) {
   return Future.value();
 }
 
-
-String ffiPaymentRedirect(planID, currency, provider, email, deviceName) {
-  final result =
-      _bindings.paymentRedirect(planID, currency, provider, email, deviceName);
-  if (result.r1 != nullptr) {
-    // Got error throw error to show error ui state
-    final errorCode = result.r1.cast<Utf8>().toDartString();
-    throw PlatformException(
-        code: errorCode,
-        message: 'we_are_experiencing_technical_difficulties'.i18n);
-  }
-  return result.r0.cast<Utf8>().toDartString();
+Future<String> ffiPaymentRedirect(List<String> list) {
+  final planID = list[0].toPointerChar();
+  final currency = list[1].toPointerChar();
+  final provider = list[2].toPointerChar();
+  final email = list[3].toPointerChar();
+  final deviceName = list[4].toPointerChar();
+  final json = _bindings
+      .paymentRedirect(planID, currency, provider, email, deviceName)
+      .cast<Utf8>()
+      .toDartString();
+  final result = PaymentRedirectResponse.create()
+    ..mergeFromProto3Json(jsonDecode(json));
+  checkAPIError(result, 'we_are_experiencing_technical_difficulties'.i18n);
+  return Future.value(result.redirect);
 }
 
 const String _libName = 'liblantern';

--- a/lib/plans/checkout.dart
+++ b/lib/plans/checkout.dart
@@ -12,7 +12,7 @@ class Checkout extends StatefulWidget {
   final Plan plan;
   final bool isPro;
 
-  Checkout({
+  const Checkout({
     required this.plan,
     required this.isPro,
     Key? key,
@@ -29,7 +29,7 @@ class _CheckoutState extends State<Checkout>
   final emailFieldKey = GlobalKey<FormState>();
   late final emailController = CustomTextEditingController(
     formKey: emailFieldKey,
-    validator: (value) => EmailValidator.validate(value ?? '')
+    validator: (value) => value!.isEmpty?null: EmailValidator.validate(value ?? '')
         ? null
         : 'please_enter_a_valid_email_address'.i18n,
   );
@@ -69,8 +69,6 @@ class _CheckoutState extends State<Checkout>
 
   @override
   void dispose() {
-    emailController.dispose();
-    refCodeController.dispose();
     animationController.dispose();
     super.dispose();
   }
@@ -244,8 +242,7 @@ class _CheckoutState extends State<Checkout>
   }
 
   bool enableContinueButton() {
-    final isEmailValid = !emailController.value.text.isEmpty &&
-        emailFieldKey.currentState!.validate();
+    final isEmailValid = EmailValidator.validate(emailController.value.text);
     if (!isRefCodeFieldShowing || refCodeController.text.isEmpty) {
       return isEmailValid;
     }
@@ -409,7 +406,7 @@ class _CheckoutState extends State<Checkout>
                           text: 'continue'.i18n,
                           // for Pro users renewing their accounts, we always have an e-mail address
                           // so it's unnecessary to disable the continue button
-                          disabled: !widget.isPro ? !showContinueButton : false,
+                          disabled: !enableContinueButton(),
                           onPressed: onContinueTapped,
                         ),
                       ),

--- a/lib/vpn/protos_shared/vpn.pb.dart
+++ b/lib/vpn/protos_shared/vpn.pb.dart
@@ -969,6 +969,98 @@ class APIResponse extends $pb.GeneratedMessage {
   void clearErrorId() => clearField(3);
 }
 
+class PaymentRedirectResponse extends $pb.GeneratedMessage {
+  factory PaymentRedirectResponse({
+    $core.String? status,
+    $core.String? error,
+    $core.String? errorId,
+    $core.String? redirect,
+  }) {
+    final $result = create();
+    if (status != null) {
+      $result.status = status;
+    }
+    if (error != null) {
+      $result.error = error;
+    }
+    if (errorId != null) {
+      $result.errorId = errorId;
+    }
+    if (redirect != null) {
+      $result.redirect = redirect;
+    }
+    return $result;
+  }
+  PaymentRedirectResponse._() : super();
+  factory PaymentRedirectResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PaymentRedirectResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'PaymentRedirectResponse', createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'status')
+    ..aOS(2, _omitFieldNames ? '' : 'error')
+    ..aOS(3, _omitFieldNames ? '' : 'errorId', protoName: 'errorId')
+    ..aOS(4, _omitFieldNames ? '' : 'redirect')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  PaymentRedirectResponse clone() => PaymentRedirectResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  PaymentRedirectResponse copyWith(void Function(PaymentRedirectResponse) updates) => super.copyWith((message) => updates(message as PaymentRedirectResponse)) as PaymentRedirectResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static PaymentRedirectResponse create() => PaymentRedirectResponse._();
+  PaymentRedirectResponse createEmptyInstance() => create();
+  static $pb.PbList<PaymentRedirectResponse> createRepeated() => $pb.PbList<PaymentRedirectResponse>();
+  @$core.pragma('dart2js:noInline')
+  static PaymentRedirectResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PaymentRedirectResponse>(create);
+  static PaymentRedirectResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get status => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set status($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasStatus() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearStatus() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get error => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set error($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasError() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearError() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get errorId => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set errorId($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasErrorId() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearErrorId() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get redirect => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set redirect($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasRedirect() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearRedirect() => clearField(4);
+}
+
 class LinkResponse extends $pb.GeneratedMessage {
   factory LinkResponse({
     $fixnum.Int64? userID,

--- a/lib/vpn/protos_shared/vpn.pbjson.dart
+++ b/lib/vpn/protos_shared/vpn.pbjson.dart
@@ -214,6 +214,23 @@ final $typed_data.Uint8List aPIResponseDescriptor = $convert.base64Decode(
     'CgtBUElSZXNwb25zZRIWCgZzdGF0dXMYASABKAlSBnN0YXR1cxIUCgVlcnJvchgCIAEoCVIFZX'
     'Jyb3ISGAoHZXJyb3JJZBgDIAEoCVIHZXJyb3JJZA==');
 
+@$core.Deprecated('Use paymentRedirectResponseDescriptor instead')
+const PaymentRedirectResponse$json = {
+  '1': 'PaymentRedirectResponse',
+  '2': [
+    {'1': 'status', '3': 1, '4': 1, '5': 9, '10': 'status'},
+    {'1': 'error', '3': 2, '4': 1, '5': 9, '10': 'error'},
+    {'1': 'errorId', '3': 3, '4': 1, '5': 9, '10': 'errorId'},
+    {'1': 'redirect', '3': 4, '4': 1, '5': 9, '10': 'redirect'},
+  ],
+};
+
+/// Descriptor for `PaymentRedirectResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List paymentRedirectResponseDescriptor = $convert.base64Decode(
+    'ChdQYXltZW50UmVkaXJlY3RSZXNwb25zZRIWCgZzdGF0dXMYASABKAlSBnN0YXR1cxIUCgVlcn'
+    'JvchgCIAEoCVIFZXJyb3ISGAoHZXJyb3JJZBgDIAEoCVIHZXJyb3JJZBIaCghyZWRpcmVjdBgE'
+    'IAEoCVIIcmVkaXJlY3Q=');
+
 @$core.Deprecated('Use linkResponseDescriptor instead')
 const LinkResponse$json = {
   '1': 'LinkResponse',

--- a/protos_shared/vpn.proto
+++ b/protos_shared/vpn.proto
@@ -78,6 +78,13 @@ message APIResponse {
   string errorId = 3;
 }
 
+message PaymentRedirectResponse {
+  string status = 1;
+  string error = 2;
+  string errorId = 3;
+  string redirect = 4;
+}
+
 message LinkResponse {
   int64 userID = 1;
   string token = 2;


### PR DESCRIPTION
- Update ffiPaymentRedirect to use compute
- Add PaymentRedirect API response type
- Update email exists check to return string instead of pointer

This also fixes an issue on main with desktop where the following error is shown after opening the payment redirect page

![Screenshot 2024-04-10 at 3 41 32 PM](https://github.com/getlantern/lantern-client/assets/6346213/f517e526-8451-4065-979f-32bc8f0f1ab5)
