### PR TITLE
Use FLAG_IMMUTABLE creating PendingIntent in ApkInstaller

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/util/ApkInstaller.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/util/ApkInstaller.kt
@@ -88,7 +88,7 @@ class ApkInstaller(
     private fun createIntentSender(sessionId: Int): IntentSender {
         val broadcastIntent = Intent(PACKAGE_INSTALLED_ACTION)
         val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE
+            PendingIntent.FLAG_IMMUTABLE
         } else {
             0
         }


### PR DESCRIPTION
04-11 14:25:50.214 26834 26935 E ApkInstaller: Failed to install apk
04-11 14:25:50.214 26834 26935 E ApkInstaller: java.lang.IllegalArgumentException: org.getlantern.lantern: Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.
