### PR TITLE
Only open Fropay in system browser on macOS

### DIFF
--- a/lib/common/ui/app_webview.dart
+++ b/lib/common/ui/app_webview.dart
@@ -46,7 +46,7 @@ class _AppWebViewState extends State<AppWebView> {
 }
 
 class AppBrowser extends InAppBrowser {
-  final Future<void> Function()? onClose;
+  final VoidCallback? onClose;
   final InAppBrowserClassSettings settings = InAppBrowserClassSettings(
       browserSettings: InAppBrowserSettings(hideUrlBar: true),
       webViewSettings: InAppWebViewSettings(

--- a/lib/plans/checkout.dart
+++ b/lib/plans/checkout.dart
@@ -288,7 +288,6 @@ class _CheckoutState extends State<Checkout>
     }
   }
 
-
   Future<void> resolvePaymentRoute() async {
     switch (selectedPaymentProvider!) {
       case Providers.stripe:
@@ -382,7 +381,10 @@ class _CheckoutState extends State<Checkout>
 
       context.loaderOverlay.hide();
       openDesktopWebview(
-          context: context, redirectUrl: redirectUrl, onClose: checkProUser);
+          context: context,
+          provider: provider,
+          redirectUrl: redirectUrl,
+          onClose: checkProUser);
     } catch (error, stackTrace) {
       context.loaderOverlay.hide();
       showError(context, error: error, stackTrace: stackTrace);

--- a/lib/plans/utils.dart
+++ b/lib/plans/utils.dart
@@ -105,14 +105,20 @@ extension PlansExtension on Plan {
 Future<void> openDesktopWebview(
     {required BuildContext context,
     required String redirectUrl,
+    required String provider,
     required VoidCallback onClose}) async {
   switch (Platform.operatingSystem) {
     case 'windows':
       await AppBrowser.openWindowsWebview(redirectUrl);
       break;
     case 'macos':
-      //Open with system browser browser on mac due to not able to by pass humans verification.
-      await InAppBrowser.openWithSystemBrowser(url: WebUri(redirectUrl));
+      if (provider == Providers.fropay.name) {
+        // Open with system browser browser on mac due to not able to by pass humans verification.
+        await InAppBrowser.openWithSystemBrowser(url: WebUri(redirectUrl));
+      } else {
+        final browser = AppBrowser(onClose: onClose);
+        await browser.openMacWebview(redirectUrl);
+      }
       break;
     default:
       await context.pushRoute(


### PR DESCRIPTION
We only want to open the redirect URL returned by `/payment-redirect` in the system browser on macOS iff the payment provider is Fropay