### PR TITLE
Fix issue updating user data over websocket

### DIFF
--- a/desktop/app/issue.go
+++ b/desktop/app/issue.go
@@ -84,7 +84,7 @@ func (reporter *issueReporter) sendIssueReport(msg *issueMessage) error {
 	}
 	subscriptionLevel := "free"
 	ctx := context.Background()
-	if isPro, _ := IsProUser(ctx, reporter.proClient, settings.GetUserID()); isPro {
+	if isPro, _ := IsProUser(ctx, reporter.proClient, settings); isPro {
 		subscriptionLevel = "pro"
 	}
 	var osVersion string

--- a/desktop/lib.go
+++ b/desktop/lib.go
@@ -258,6 +258,7 @@ func getUserData() (*protos.User, error) {
 //export hasPlanUpdatedOrBuy
 func hasPlanUpdatedOrBuy() *C.char {
 	//Get the cached user data
+	log.Debugf("DEBUG: Checking if user has updated plan or bought new plan")
 	uc := userConfig(a.Settings())
 	cahcheUserData, isOldFound := app.GetUserDataFast(context.Background(), uc.GetUserID())
 	//Get latest user data

--- a/desktop/lib.go
+++ b/desktop/lib.go
@@ -459,7 +459,7 @@ func acceptedTermsVersion() *C.char {
 func proUser() *C.char {
 	ctx := context.Background()
 	// refresh user data when home page is loaded on desktop
-	go proClient.UserData(ctx)
+	go getUserData()
 	uc := a.Settings()
 	if isProUser, ok := app.IsProUserFast(ctx, uc); isProUser && ok {
 		return C.CString("true")

--- a/desktop/lib.go
+++ b/desktop/lib.go
@@ -260,13 +260,11 @@ func hasPlanUpdatedOrBuy() *C.char {
 	//Get the cached user data
 	uc := userConfig(a.Settings())
 	cahcheUserData, isOldFound := app.GetUserDataFast(context.Background(), uc.GetUserID())
-	log.Debugf("DEBUG: cached user data: Expiration %v UserLevel %v", cahcheUserData.Expiration, cahcheUserData.UserLevel)
 	//Get latest user data
 	resp, err := proClient.UserData(context.Background())
 	if err != nil {
 		return sendError(err)
 	}
-	log.Debugf("DEBUG: latest user data: Expiration %v UserLevel %v", resp.User.Expiration, resp.User.UserLevel)
 	if isOldFound {
 		if cahcheUserData.Expiration < resp.User.Expiration {
 			// New data has a later expiration

--- a/lib/account/account.dart
+++ b/lib/account/account.dart
@@ -31,7 +31,7 @@ class AccountMenu extends StatelessWidget {
           borderRadius: BorderRadius.only(
               topLeft: Radius.circular(16), topRight: Radius.circular(16))),
       builder: (context) {
-        return FollowUs();
+        return const FollowUs();
       },
     );
   }

--- a/lib/common/session_model.dart
+++ b/lib/common/session_model.dart
@@ -479,6 +479,11 @@ class SessionModel extends Model {
     return methodChannel.invokeMethod('updatePaymentPlans');
   }
 
+  Future<bool> hasUpdatePlansOrBuy() async {
+    return compute(ffiHasPlanUpdateOrBuy,'');
+  }
+
+
   Plan planFromJson(Map<String, dynamic> item) {
     print("called plans $item");
     final locale = Localization.locale;

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -47,9 +47,10 @@ Future<User> ffiUserData() async {
 
 // checkAPIError throws a PlatformException if the API response contains an error
 void checkAPIError(result, errorMessage) {
-  if(result is String){
-    final  errorMessageMap = jsonDecode(result);
-    throw PlatformException(code:errorMessageMap.toString(), message: errorMessage);
+  if (result is String) {
+    final errorMessageMap = jsonDecode(result);
+    throw PlatformException(
+        code: errorMessageMap.toString(), message: errorMessage);
   }
   if (result.error != "") {
     throw PlatformException(code: result.error, message: errorMessage);
@@ -80,13 +81,10 @@ Future<void> ffiRemoveDevice(String deviceId) async {
   return;
 }
 
-FutureOr<bool> ffiHasPlanUpdateOrBuy(dynamic context)  {
-  final json = _bindings
-      .hasPlanUpdatedOrBuy()
-      .cast<Utf8>()
-      .toDartString();
+FutureOr<bool> ffiHasPlanUpdateOrBuy(dynamic context) {
+  final json = _bindings.hasPlanUpdatedOrBuy().cast<Utf8>().toDartString();
   print('Result of hasPlanUpdatedOrBuy: $json');
-  return json=='true';
+  return json == 'true' ? true : throw NoPlansUpdate("No Plans update");
 }
 
 Pointer<Utf8> ffiDevices() => _bindings.devices().cast<Utf8>();
@@ -126,7 +124,9 @@ Pointer<Utf8> ffiCheckUpdates() => _bindings.checkUpdates().cast<Utf8>();
 Pointer<Utf8> ffiPlans() => _bindings.plans().cast<Utf8>();
 
 Pointer<Utf8> ffiPaymentMethods() => _bindings.paymentMethodsV3().cast<Utf8>();
-Pointer<Utf8> ffiPaymentMethodsV4() => _bindings.paymentMethodsV4().cast<Utf8>();
+
+Pointer<Utf8> ffiPaymentMethodsV4() =>
+    _bindings.paymentMethodsV4().cast<Utf8>();
 
 Pointer<Utf8> ffiDeviceLinkingCode() =>
     _bindings.deviceLinkingCode().cast<Utf8>();
@@ -194,4 +194,12 @@ final NativeLibrary _bindings = NativeLibrary(_dylib);
 
 void loadLibrary() {
   _bindings.start();
+}
+
+//Custom exception for handling error
+
+class NoPlansUpdate implements Exception {
+  String message;
+
+  NoPlansUpdate(this.message);
 }

--- a/lib/ffi.dart
+++ b/lib/ffi.dart
@@ -80,6 +80,15 @@ Future<void> ffiRemoveDevice(String deviceId) async {
   return;
 }
 
+FutureOr<bool> ffiHasPlanUpdateOrBuy(dynamic context)  {
+  final json = _bindings
+      .hasPlanUpdatedOrBuy()
+      .cast<Utf8>()
+      .toDartString();
+  print('Result of hasPlanUpdatedOrBuy: $json');
+  return json=='true';
+}
+
 Pointer<Utf8> ffiDevices() => _bindings.devices().cast<Utf8>();
 
 Pointer<Utf8> ffiDevelopmentMode() => _bindings.developmentMode().cast<Utf8>();

--- a/lib/plans/checkout.dart
+++ b/lib/plans/checkout.dart
@@ -477,18 +477,24 @@ class _CheckoutState extends State<Checkout>
     }
   }
 
-
+  ///This methods is responsible for polling for user data
+  ///so if user has done payment or renew plans and show
   void hasPlansUpdateOrBuy() {
+    appLogger.i("calling hasPlansUpdateOrBuy to update plans or buy");
     try {
-      retry(() async {
-        /// Polling for userData that user has updates plans or buy
-        final plansUpdated = await sessionModel.hasUpdatePlansOrBuy();
-        if (plansUpdated) {
-          if (mounted) {
-            showSuccessDialog(context, widget.isPro);
+      retry(
+        () async {
+          /// Polling for userData that user has updates plans or buy
+          final plansUpdated = await sessionModel.hasUpdatePlansOrBuy();
+          if (plansUpdated) {
+            if (mounted) {
+              showSuccessDialog(context, widget.isPro);
+            }
           }
-        }
-      });
+        },
+        delayFactor: const Duration(seconds: 2),
+        retryIf: (e) => e is NoPlansUpdate,
+      );
     } catch (e) {
       appLogger.e('Error while polling for plans update or buy', error: e);
     }

--- a/lib/plans/utils.dart
+++ b/lib/plans/utils.dart
@@ -102,12 +102,11 @@ extension PlansExtension on Plan {
   }
 }
 
-Future<void> openDesktopWebview({
-  required BuildContext context,
-  required String redirectUrl,
-  required String provider,
-  required VoidCallback onClose,
-}) async {
+Future<void> openDesktopWebview(
+    {required BuildContext context,
+    required String redirectUrl,
+    required String provider,
+    required VoidCallback onClose}) async {
   switch (Platform.operatingSystem) {
     case 'windows':
       await AppBrowser.openWindowsWebview(redirectUrl);

--- a/lib/plans/utils.dart
+++ b/lib/plans/utils.dart
@@ -102,11 +102,12 @@ extension PlansExtension on Plan {
   }
 }
 
-Future<void> openDesktopWebview(
-    {required BuildContext context,
-    required String redirectUrl,
-    required String provider,
-    required VoidCallback onClose}) async {
+Future<void> openDesktopWebview({
+  required BuildContext context,
+  required String redirectUrl,
+  required String provider,
+  required VoidCallback onClose,
+}) async {
   switch (Platform.operatingSystem) {
     case 'windows':
       await AppBrowser.openWindowsWebview(redirectUrl);

--- a/lib/plans/utils.dart
+++ b/lib/plans/utils.dart
@@ -113,7 +113,7 @@ Future<void> openDesktopWebview(
       break;
     case 'macos':
       if (provider == Providers.fropay.name) {
-        // Open with system browser browser on mac due to not able to by pass humans verification.
+        // Open with system browser browser on mac due to not able to by pass human verification.
         await InAppBrowser.openWithSystemBrowser(url: WebUri(redirectUrl));
       } else {
         final browser = AppBrowser(onClose: onClose);


### PR DESCRIPTION
In the old Pro client, whenever we fetch user data, it is stored afterwards in a local cache. Whenever that cache changes, the updates are sent over the websocket channel: https://github.com/getlantern/flashlight/blob/main/pro/user_data.go#L154

It looks this was left out of the [new Pro client](https://github.com/getlantern/lantern-client/pull/1033), and we were no longer receiving user data updates in real-time: https://github.com/getlantern/lantern-client/blob/7163452b617d7a7384d2f050bfbf80cde38db3fb/lib/common/session_model.dart#L94