### PR TITLE
Update how i18n imports translations

### DIFF
--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -19,7 +19,7 @@ export 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 export 'package:flutter_localizations/flutter_localizations.dart';
 export 'package:flutter_svg/flutter_svg.dart';
 export 'package:flutter_switch/flutter_switch.dart';
-export 'package:i18n_extension/i18n_widget.dart';
+export 'package:i18n_extension/src/i18n_widget.dart';
 export 'package:lantern/core/router/router.gr.dart';
 export 'package:lantern/event_extension.dart';
 export 'package:lantern/event_manager.dart';

--- a/lib/i18n/i18n.dart
+++ b/lib/i18n/i18n.dart
@@ -1,19 +1,19 @@
+import 'package:i18n_extension_importer/src/io/import.dart';
 import 'package:i18n_extension/i18n_extension.dart';
-import 'package:i18n_extension/io/import.dart';
 import 'package:lantern/common/common.dart';
 
 extension Localization on String {
   static String defaultLocale = 'en';
   static String locale = defaultLocale;
 
-  static TranslationsByLocale translations =
+  static Translations translations =
       Translations.byLocale(defaultLocale);
 
-  static Future<TranslationsByLocale> Function(
-    Future<TranslationsByLocale> Function(),
-  ) loadTranslationsOnce = once<Future<TranslationsByLocale>>();
+  static Future<Translations> Function(
+    Future<Translations> Function(),
+  ) loadTranslationsOnce = once<Future<Translations>>();
 
-  static Future<TranslationsByLocale> ensureInitialized() async {
+  static Future<Translations> ensureInitialized() async {
     return loadTranslationsOnce(() {
       return GettextImporter()
           .fromAssetDirectory('assets/locales')

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -712,6 +712,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.17"
+  flutter_staggered_grid_view:
+    dependency: transitive
+    description:
+      name: flutter_staggered_grid_view
+      sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_svg:
     dependency: transitive
     description:
@@ -776,6 +784,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  gettext_parser:
+    dependency: transitive
+    description:
+      name: gettext_parser
+      sha256: "9565c9dd1033ec125e1fbc7ccba6c0d2d753dd356122ba1a17e6aa7dc868f34a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   glob:
     dependency: transitive
     description:
@@ -864,14 +880,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
+  i18n_extension_importer:
+    dependency: "direct main"
+    description:
+      name: i18n_extension_importer
+      sha256: "4fd651ff47ac52f604b34b5cd80ee225d38fe589d51b042f00178081b476252f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.6"
   infinite_scroll_pagination:
     dependency: "direct main"
     description:
       name: infinite_scroll_pagination
-      sha256: "9517328f4e373f08f57dbb11c5aac5b05554142024d6b60c903f3b73476d52db"
+      sha256: b68bce20752fcf36c7739e60de4175494f74e99e9a69b4dd2fe3a1dd07a7f16a
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   integration_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   emoji_picker_flutter: ^1.6.4
   pin_code_text_field: ^1.8.0
   scrollable_positioned_list: ^0.3.8
-  infinite_scroll_pagination: ^3.2.0
+  infinite_scroll_pagination: ^4.0.0
   wakelock: ^0.6.2
   email_validator: ^2.1.17
   credit_card_validator: ^2.1.0
@@ -77,6 +77,7 @@ dependencies:
   # Navigation & Localization
   auto_route: ^7.8.4
   i18n_extension: ^12.0.1
+  i18n_extension_importer: ^0.0.6
   intl: ^0.19.0
 
   # QR


### PR DESCRIPTION
Some changes to handle upgrading intl to 0.19.0 and i18n_extension to 12.0.1

```
➜  lantern-client git:(atavism/7.8.6) ✗ flutter pub get
Resolving dependencies...
Note: intl is pinned to version 0.19.0 by flutter_localizations from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because lantern depends on flutter_localizations from sdk which depends on intl 0.19.0, intl 0.19.0 is required.
So, because lantern depends on intl ^0.18.0, version solving failed.
```

```
➜  lantern-client git:(atavism/7.8.6) ✗ flutter build macos

--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:arm64, id:00008112-000809843A08201E, name:My Mac }
{ platform:macOS, arch:x86_64, id:00008112-000809843A08201E, name:My Mac }
lib/common/common.dart:22:1: Error: Error when reading '../../../../../.pub-cache/hosted/pub.dev/i18n_extension-12.0.1/lib/i18n_widget.dart': No such file or directory
export 'package:i18n_extension/i18n_widget.dart';
^
lib/i18n/i18n.dart:11:17: Error: Type 'TranslationsByLocale' not found.
  static Future<TranslationsByLocale> Function(
                ^^^^^^^^^^^^^^^^^^^^
lib/i18n/i18n.dart:12:12: Error: Type 'TranslationsByLocale' not found.
    Future<TranslationsByLocale> Function(),
           ^^^^^^^^^^^^^^^^^^^^
lib/i18n/i18n.dart:15:17: Error: Type 'TranslationsByLocale' not found.
  static Future<TranslationsByLocale> ensureInitialized() async {
                ^^^^^^^^^^^^^^^^^^^^
lib/app.dart:140:24: Error: The method 'I18n' isn't defined for the class '_LanternAppState'.
 - '_LanternAppState' is from 'package:lantern/app.dart' ('lib/app.dart').
Try correcting the name to the name of an existing method, or defining a method named 'I18n'.
                child: I18n(
```