### PR TITLE
install yq prior to building desktop app on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -129,7 +129,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
-
+      # Using flutter-version-file requires yq, which is not pre-installed in windows images
+      - run: choco install yq
       # Install Flutter
       - uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION
For flutter-version-file to work on Windows, yq has to be installed first

https://github.com/mikefarah/yq