### PR TITLE
Update pro client request middleware

### DIFF
--- a/internalsdk/pro/pro.go
+++ b/internalsdk/pro/pro.go
@@ -63,6 +63,7 @@ func NewClient(baseURL string, opts *Opts) ProClient {
 	return client
 }
 
+// prepareProRequest normalizes requests to the pro server with device ID, user ID, etc set.
 func prepareProRequest(userConfig func() common.UserConfig) func(client *resty.Client, req *http.Request) error {
 	return func(client *resty.Client, req *http.Request) error {
 		uc := userConfig()

--- a/internalsdk/pro/pro.go
+++ b/internalsdk/pro/pro.go
@@ -59,13 +59,13 @@ func NewClient(baseURL string, opts *Opts) ProClient {
 	client := &proClient{
 		userConfig: opts.UserConfig,
 	}
-	client.webclient = webclient.NewRESTClient(defaultwebclient.SendToURL(httpClient, baseURL, client.setUserHeaders(), nil))
+	client.webclient = webclient.NewRESTClient(defaultwebclient.SendToURL(httpClient, baseURL, prepareProRequest(opts.UserConfig), nil))
 	return client
 }
 
-func (c *proClient) setUserHeaders() func(client *resty.Client, req *http.Request) error {
+func prepareProRequest(userConfig func() common.UserConfig) func(client *resty.Client, req *http.Request) error {
 	return func(client *resty.Client, req *http.Request) error {
-		uc := c.userConfig()
+		uc := userConfig()
 		req.Header.Set("Referer", "http://localhost:37457/")
 		req.Header.Set("Access-Control-Allow-Headers", strings.Join([]string{
 			common.DeviceIdHeader,

--- a/internalsdk/pro/pro.go
+++ b/internalsdk/pro/pro.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 
 	"github.com/getlantern/errors"
@@ -73,11 +72,7 @@ func (c *proClient) setUserHeaders() func(client *resty.Client, req *http.Reques
 			common.ProTokenHeader,
 			common.UserIdHeader,
 		}, ", "))
-		// Add auth headers only if not present, to avoid race conditions when creating new user or switching user, i.e., linking device
-		// to a new account.
 		common.AddCommonHeadersWithOptions(uc, req, false)
-		d, _ := httputil.DumpRequest(req, false)
-		log.Debugf("Dump is %s", string(d))
 		return nil
 	}
 }

--- a/internalsdk/pro/pro.go
+++ b/internalsdk/pro/pro.go
@@ -67,7 +67,6 @@ func NewClient(baseURL string, opts *Opts) ProClient {
 func prepareProRequest(userConfig func() common.UserConfig) func(client *resty.Client, req *http.Request) error {
 	return func(client *resty.Client, req *http.Request) error {
 		uc := userConfig()
-		req.Header.Set("Referer", "http://localhost:37457/")
 		req.Header.Set("Access-Control-Allow-Headers", strings.Join([]string{
 			common.DeviceIdHeader,
 			common.ProTokenHeader,

--- a/internalsdk/pro/webclient/defaultwebclient/rest.go
+++ b/internalsdk/pro/webclient/defaultwebclient/rest.go
@@ -18,10 +18,10 @@ var (
 
 // Create function that sends requests to the given URL, optionally sending them through a proxy,
 // optionally processing requests with the given beforeRequest middleware and/or responses with the given afterResponse middleware.
-func SendToURL(httpClient *http.Client, baseURL string, beforeRequest resty.RequestMiddleware, afterResponse resty.ResponseMiddleware) webclient.SendRequest {
+func SendToURL(httpClient *http.Client, baseURL string, beforeRequest resty.PreRequestHook, afterResponse resty.ResponseMiddleware) webclient.SendRequest {
 	c := resty.NewWithClient(httpClient)
 	if beforeRequest != nil {
-		c.OnBeforeRequest(beforeRequest)
+		c.SetPreRequestHook(beforeRequest)
 	}
 	if afterResponse != nil {
 		c.OnAfterResponse(afterResponse)


### PR DESCRIPTION
This PR updates defaultwebclient to use a different type of request middleware where RawRequest is not nil.

go-resty has "three types of request middleware, and they are performed in sequence:

- udBeforeRequest chain (registered by Client.onBeforeRequest)
- beforeRequest chain (default middleware registered by resty)
- preReqHook hook (registered by Client.SetPreRequestHook)

RawRequest is initialized at the second chain. Therefore, we get nil in our onBeforeRequest function."