### PR TITLE
Remove use of USE_FULL_SCREEN_INTENT permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,9 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
     -->
+    <!-- 
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,8 +13,6 @@
     <!-- Re-enable for Chat!
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-    -->
-    <!-- 
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />


### PR DESCRIPTION
The latest build submitted to the Play store was rejected because they found "that [our] app is not compliant with how the USE_FULL_SCREEN_INTENT permission is allowed to be used. Specifically, the use of the permission is not directly related to the core purpose of the app ... Apps will only be automatically granted to use the USE_FULL_SCREEN_INTENT permission if the core functionality of their app falls under one of the below categories that require high priority notifications: setting an alarm or receiving phone or video calls"