### PR TITLE
Open privacy policy and terms of service in browser on mobile

### DIFF
--- a/lib/account/settings.dart
+++ b/lib/account/settings.dart
@@ -34,13 +34,8 @@ class Settings extends StatelessWidget {
   void openSplitTunneling(BuildContext context) =>
       context.pushRoute(SplitTunneling());
 
-  void openWebView(String url, BuildContext context, String title) async {
-    if (isDesktop()) {
-      await InAppBrowser.openWithSystemBrowser(url: WebUri(url));
-    } else if (isMobile()) {
-      context.pushRoute(AppWebview(url: url, title: title));
-    }
-  }
+  void openWebView(String url, BuildContext context, String title) async =>
+    await InAppBrowser.openWithSystemBrowser(url: WebUri(url));
 
   Future<void> checkForUpdateTap(BuildContext context) async {
     if (Platform.isAndroid) {


### PR DESCRIPTION
Resolves https://github.com/getlantern/engineering/issues/1499

Opens the privacy policy and terms of service pages in the system browser on mobile instead of an in app webview (which is currently displaying a blank page)