### PR TITLE
Update hit_proxy script to use bin/lc

### DIFF
--- a/hit_proxy.bash
+++ b/hit_proxy.bash
@@ -14,7 +14,7 @@ rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR"
 
 echo "Generating config for ${PROXY} in ${OUTFILE}..."
-$LANTERN_CLOUD/bin/ptool route dump-config --legacy "$PROXY" > "$OUTFILE"
+$LANTERN_CLOUD/bin/lc route dump-config --legacy "$PROXY" > "$OUTFILE"
 
 make darwin ffigen
 LANTERN_CONFIGDIR=$TMPDIR \


### PR DESCRIPTION
ptool has been subsumed by `lantern-cloud/bin/lc`. This PR updates hit_proxy.bash to use it instead.