### PR TITLE
Specify default values for provider icons

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/model/PaymentMethod.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/model/PaymentMethod.kt
@@ -39,5 +39,5 @@ data class PaymentMethods(
 @Serializable
 data class Icons(
     @SerialName("paymentwall") var paymentwall: List<String> = mutableListOf<String>(),
-    @SerialName("stripe") val stripe: List<String> = mutableListOf<String>()>,
+    @SerialName("stripe") var stripe: List<String> = mutableListOf<String>(),
 )

--- a/android/app/src/main/kotlin/org/getlantern/lantern/model/PaymentMethod.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/model/PaymentMethod.kt
@@ -38,6 +38,6 @@ data class PaymentMethods(
 
 @Serializable
 data class Icons(
-    @SerialName("paymentwall") val paymentwall: List<String>,
-    @SerialName("stripe") val stripe: List<String>
+    @SerialName("paymentwall") var paymentwall: List<String> = mutableListOf<String>(),
+    @SerialName("stripe") val stripe: List<String> = mutableListOf<String>()>,
 )


### PR DESCRIPTION
Resolves the following issue:

```
08-21 18:51:58.859 17375 17608 E JsonUtil: Unable to parse JSON
08-21 18:51:58.859 17375 17608 E JsonUtil: kotlinx.serialization.MissingFieldException: Field 'paymentwall' is required for type with serial name 'org.getlantern.lantern.model.Icons', but it was missing at path: $
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(SourceFile:95)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at kotlinx.serialization.json.Json.decodeFromString(SourceFile:165)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at org.getlantern.lantern.model.LanternHttpClient$plansV4$1.onSuccess(SourceFile:147)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at org.getlantern.lantern.model.LanternHttpClient$proRequest$1.onResponse(SourceFile:309)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at okhttp3.internal.connection.RealCall$AsyncCall.run(SourceFile:519)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at java.lang.Thread.run(Thread.java:1012)
08-21 18:51:58.859 17375 17608 E JsonUtil: Caused by: kotlinx.serialization.MissingFieldException: Field 'paymentwall' is required for type with serial name 'org.getlantern.lantern.model.Icons', but it was missing
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(SourceFile:20)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at org.getlantern.lantern.model.Icons.<init>(SourceFile:39)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at org.getlantern.lantern.model.Icons$$serializer.deserialize(SourceFile:39)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at org.getlantern.lantern.model.Icons$$serializer.deserialize(SourceFile:39)
08-21 18:51:58.859 17375 17608 E JsonUtil: 	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(SourceFile:69)
```