### PR TITLE
delay call to setState with addPostFrameCallback

### DIFF
--- a/lib/vpn/vpn_switch.dart
+++ b/lib/vpn/vpn_switch.dart
@@ -39,7 +39,7 @@ class _VPNSwitchState extends State<VPNSwitch> {
     //if ads is not ready then wait for at least 5 seconds and then show ads
     //if ads is ready then show ads immediately
 
-    if(Platform.isAndroid){
+    if (Platform.isAndroid) {
       if (vpnStatus != 'connected' && userHasPermission) {
         if (!await adHelper.isAdsReadyToShow()) {
           await vpnModel.connectingDelay(newValue);
@@ -82,8 +82,9 @@ class _VPNSwitchState extends State<VPNSwitch> {
             disabledOpacity: 1,
             enabled: (internetStatusProvider.isConnected &&
                 !vpnNotifier.isFlashlightInitializedFailed),
-            initialValue:
-                vpnStatus == 'connected' || vpnStatus == 'disconnecting' ||vpnStatus == 'connecting',
+            initialValue: vpnStatus == 'connected' ||
+                vpnStatus == 'disconnecting' ||
+                vpnStatus == 'connecting',
             activeColor: onSwitchColor,
             inactiveColor: (internetStatusProvider.isConnected &&
                     !vpnNotifier.isFlashlightInitializedFailed)
@@ -115,8 +116,10 @@ class _VPNSwitchState extends State<VPNSwitch> {
                 : grey3,
             onChanged: (newValue) {
               vpnProcessForDesktop();
-              setState(() {
-                this.vpnStatus = newValue ? 'connected' : 'disconnected';
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                setState(() {
+                  this.vpnStatus = newValue ? 'connected' : 'disconnected';
+                });
               });
             },
           );

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -49,9 +49,6 @@ PODS:
   - video_player_avfoundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - webview_flutter_wkwebview (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - window_manager (0.2.0):
     - FlutterMacOS
 
@@ -76,7 +73,6 @@ DEPENDENCIES:
   - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
-  - webview_flutter_wkwebview (from `Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 SPEC REPOS:
@@ -125,8 +121,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   video_player_avfoundation:
     :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
-  webview_flutter_wkwebview:
-    :path: Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin
   window_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
@@ -153,7 +147,6 @@ SPEC CHECKSUMS:
   tray_manager: 9064e219c56d75c476e46b9a21182087930baf90
   url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
   video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
-  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 
 PODFILE CHECKSUM: b026caf428aef5db8f45e6734a110a98281273f6


### PR DESCRIPTION
For https://github.com/getlantern/engineering/issues/1652

```
══╡ EXCEPTION CAUGHT BY FOUNDATION LIBRARY ╞════════════════════════════════════════════════════════
The following assertion was thrown while dispatching notifications for ValueNotifier<bool>:
setState() or markNeedsBuild() called during build.
This VPNSwitch widget cannot be marked as needing to build because the framework is already in the
process of building widgets. A widget can be marked as needing to be built during the build phase
only if one of its ancestors is currently building. This exception is allowed because the framework
builds parent widgets before children, which means a dirty descendant will always be built.
Otherwise, the framework might not visit this widget during this build phase.
The widget on which setState() or markNeedsBuild() was called was:
  VPNSwitch
The widget which was currently being built when the offending call was made was:
  FfiValueBuilder<String>

When the exception was thrown, this was the stack:
#0      Element.markNeedsBuild.<anonymous closure> (package:flutter/src/widgets/framework.dart:5177:9)
#1      Element.markNeedsBuild (package:flutter/src/widgets/framework.dart:5189:6)
#2      State.setState (package:flutter/src/widgets/framework.dart:1223:15)
#3      _VPNSwitchState.build.<anonymous closure>.<anonymous closure> (package:lantern/vpn/vpn_switch.dart:118:15)
#4      _AdvancedSwitchState._handleControllerValueChanged (package:flutter_advanced_switch/flutter_advanced_switch.dart:279:23)
#5      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:437:24)
#6      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:559:5)
#7      _AdvancedSwitchState.didUpdateWidget (package:flutter_advanced_switch/flutter_advanced_switch.dart:108:24)
#8      StatefulElement.update (package:flutter/src/widgets/framework.dart:5789:55)
#9      Element.updateChild (package:flutter/src/widgets/framework.dart:3941:15)
#10     ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:5642:16)
#11     StatefulElement.performRebuild (package:flutter/src/widgets/framework.dart:5780:11)
#12     Element.rebuild (package:flutter/src/widgets/framework.dart:5333:7)
#13     BuildScope._tryRebuild (package:flutter/src/widgets/framework.dart:2693:15)
#14     BuildScope._flushDirtyElements (package:flutter/src/widgets/framework.dart:2752:11)
#15     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:3048:18)
#16     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1162:21)
#17     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:468:5)
#18     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1397:15)
#19     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1318:9)
#20     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1176:5)
#21     _invoke (dart:ui/hooks.dart:312:13)
#22     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:419:5)
#23     _drawFrame (dart:ui/hooks.dart:283:31)
```