### PR TITLE
Always show data cap on desktop

### DIFF
--- a/lib/features/vpn/vpn_bandwidth.dart
+++ b/lib/features/vpn/vpn_bandwidth.dart
@@ -8,7 +8,7 @@ class VPNBandwidth extends StatelessWidget {
     return sessionModel
         .bandwidth((BuildContext context, Bandwidth bandwidth, Widget? child) {
       // User does not have bandwidth cap off
-      if (bandwidth.remaining > 0) {
+      if (bandwidth.remaining > 0 || isDesktop()) {
         if (bandwidth.percent.isZero) bandwidth.percent = bandwidth.remaining;
         return Column(
           children: [


### PR DESCRIPTION
Fix for the following issue: "When first installed, I saw a data cap, but when I did a clean install on another Windows user account, I saw no data cap. After about 10 minutes of use, the data cap showed up again."

This is happening because we only display the data cap once we receive a bandwidth update for the first time. We should update the code to do that if the feature is enabled instead but for now I'm just always enabling it on desktop to fix the immediate issue.
