### PR TITLE
updating autoupdate and run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/eycorsican/go-tun2socks v1.16.12-0.20201107203946-301549c435ff
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getlantern/appdir v0.0.0-20200615192800-a0ef1968f4da
-	github.com/getlantern/autoupdate v0.0.0-20211217175350-d0b211f39ba7
+	github.com/getlantern/autoupdate v0.0.0-20240926204302-11d9aa2df948
 	github.com/getlantern/common v1.2.1-0.20230427204521-6ac18c21db39
 	github.com/getlantern/diagnostics v0.0.0-20230503185158-c2fc28ed22fe
 	github.com/getlantern/dnsgrab v0.0.0-20240830183253-5c3e2386c39e

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/getlantern/algeneva v0.0.0-20240605225338-caba0b3edf03 h1:VaBQdRGkP47
 github.com/getlantern/algeneva v0.0.0-20240605225338-caba0b3edf03/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
 github.com/getlantern/appdir v0.0.0-20200615192800-a0ef1968f4da h1:T/pxF37Z9SIQCHhMMUITZ3rhKRL0Noi9XxNwxKdBNw0=
 github.com/getlantern/appdir v0.0.0-20200615192800-a0ef1968f4da/go.mod h1:3vR6+jQdWfWojZ77w+htCqEF5MO/Y2twJOpAvFuM9po=
-github.com/getlantern/autoupdate v0.0.0-20211217175350-d0b211f39ba7 h1:/efTOJpxXC/DglC3qTt3P7kQZA7jPO3+1PLsfH+mc7k=
-github.com/getlantern/autoupdate v0.0.0-20211217175350-d0b211f39ba7/go.mod h1:+X8pAviVhThDBjPEqLUB0iO7EPxhpWk7Q9VYxvz6rCY=
+github.com/getlantern/autoupdate v0.0.0-20240926204302-11d9aa2df948 h1:QPpGiY3ljAaNe3qdx22cTVzDPQLS/4yUeuvyGgfADCA=
+github.com/getlantern/autoupdate v0.0.0-20240926204302-11d9aa2df948/go.mod h1:ohIVs2H6Wb58ZaCw/OAP+z6RPFVaRokAnldy+ATGwdQ=
 github.com/getlantern/broflake v0.0.0-20240726141511-b0693659265d h1:1CP0+0UYTn/sl0VfQhcvaisAZxoCqVoTfsl59dmajb0=
 github.com/getlantern/broflake v0.0.0-20240726141511-b0693659265d/go.mod h1:tiDZ3G1JdjwLZDG0O4LYpeFMAxGjFb9L15s7NO4ibVk=
 github.com/getlantern/bufconn v0.0.0-20190625204133-a08544339f8d/go.mod h1:d6O4RY+V87kIt4o9wru4SaNo7C2NAkD3YnmJFXEpODo=


### PR DESCRIPTION
This pull request is updating the reference to the latest audoupdate version that validates the response code from the downloaded version is different than 200. We're doing this so we can try to understand better why the `autoupdate_download` operation is failing. See https://github.com/getlantern/autoupdate/pull/11 for more details

- [ ] New code should not be using FutureBuilder (use ValueListenableBuilder instead)
- [ ] All strings are defined using localized message keys like `'my_message_key'.i18n` and are defined in `en.po`.
- [ ] All colors are defined using Hex (not using built-in colors), are defined in `colors.dart` and are not duplicated
- [ ] All text styles are defined in `text_styles.dart` and are not duplicated
- [ ] All icons are using the vector resource from Figma (do not use built-in Icons)
- [ ] Repeated code has been factored into custom widgets
- [ ] Layout looks good in both LTR (English) and RTL (Persian) languages
- [ ] If you refactored existing code, have you tested the refactored functionality against the old version to make sure you didn't break anything?
- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?
