### PR TITLE
Add Window container

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,8 +5,9 @@ import 'package:lantern/core/router/router.dart';
 import 'package:lantern/core/widgtes/custom_bottom_bar.dart';
 import 'package:lantern/features/messaging/messaging.dart';
 import 'package:lantern/features/vpn/vpn_notifier.dart';
-import 'common/ui/custom/internet_checker.dart';
+import 'package:lantern/features/window/window_container.dart';
 
+import 'common/ui/custom/internet_checker.dart';
 
 final navigatorKey = GlobalKey<NavigatorState>();
 final globalRouter = AppRouter();
@@ -121,28 +122,30 @@ class _LanternAppState extends State<LanternApp>
       providers: [
         ChangeNotifierProvider(create: (context) => BottomBarChangeNotifier()),
         ChangeNotifierProvider(create: (context) => VPNChangeNotifier()),
-        ChangeNotifierProvider(create: (context) => InternetStatusProvider())
+        ChangeNotifierProvider(create: (context) => InternetStatusProvider()),
+        ChangeNotifierProvider(create: (context) => WindowNotifier()),
       ],
       child: sessionModel.language(
         (context, lang, child) {
           Localization.locale = lang.startsWith('en') ? "en_us" : lang;
           return GlobalLoaderOverlay(
-              useDefaultLoading: false,
-              overlayColor: Colors.black.withOpacity(0.5),
-              overlayWidget: Center(
-                child: AnimatedLoadingBorder(
-                  borderWidth: 5,
-                  borderColor: yellow3,
-                  cornerRadius: 100,
-                  child: SvgPicture.asset(
-                    ImagePaths.lantern_logo,
-                  ),
+            useDefaultLoading: false,
+            overlayColor: Colors.black.withOpacity(0.5),
+            overlayWidget: Center(
+              child: AnimatedLoadingBorder(
+                borderWidth: 5,
+                borderColor: yellow3,
+                cornerRadius: 100,
+                child: SvgPicture.asset(
+                  ImagePaths.lantern_logo,
                 ),
               ),
-              child: I18n(
-                initialLocale: currentLocale(lang),
-                child: ScaffoldMessenger(
-                  child: MaterialApp.router(
+            ),
+            child: I18n(
+              initialLocale: currentLocale(lang),
+              child: ScaffoldMessenger(
+                child: WindowContainer(
+                  MaterialApp.router(
                     locale: currentLocale(lang),
                     debugShowCheckedModeBanner: false,
                     theme: ThemeData(
@@ -184,7 +187,9 @@ class _LanternAppState extends State<LanternApp>
                     ],
                   ),
                 ),
-              ));
+              ),
+            ),
+          );
         },
       ),
     );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -123,7 +123,6 @@ class _LanternAppState extends State<LanternApp>
         ChangeNotifierProvider(create: (context) => BottomBarChangeNotifier()),
         ChangeNotifierProvider(create: (context) => VPNChangeNotifier()),
         ChangeNotifierProvider(create: (context) => InternetStatusProvider()),
-        ChangeNotifierProvider(create: (context) => WindowNotifier()),
       ],
       child: sessionModel.language(
         (context, lang, child) {

--- a/lib/features/window/window_container.dart
+++ b/lib/features/window/window_container.dart
@@ -1,0 +1,95 @@
+import 'package:lantern/app.dart';
+import 'package:lantern/core/service/lantern_ffi_service.dart';
+import 'package:lantern/core/utils/common.dart';
+import 'package:tray_manager/tray_manager.dart';
+import 'package:window_manager/window_manager.dart';
+
+class WindowNotifier extends ChangeNotifier {
+  bool _isInitialized = false;
+  bool get isInitialized => _isInitialized;
+
+  Future<void> initialize() async {
+    await windowManager.ensureInitialized();
+    const double width = 360;
+    const double height = 712;
+
+    await windowManager.setSize(const Size(width, height));
+    _isInitialized = true;
+    notifyListeners();
+  }
+
+  Future<void> close() async {
+    await windowManager.hide();
+    if (Platform.isMacOS) {
+      await windowManager.setSkipTaskbar(true);
+    }
+  }
+}
+
+class WindowContainer extends StatefulWidget {
+  const WindowContainer(this.child, {super.key});
+
+  final Widget child;
+
+  @override
+  State<WindowContainer> createState() => _WindowContainerState();
+}
+
+class _WindowContainerState extends State<WindowContainer> with WindowListener {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: Provider.of<WindowNotifier>(context, listen: false).initialize(),
+      builder: (context, snapshot) {
+        return widget.child;
+      },
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    windowManager.addListener(this);
+    if (isDesktop()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        await windowManager.setPreventClose(true);
+        await windowManager.setResizable(false);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    windowManager.removeListener(this);
+    super.dispose();
+  }
+
+  @override
+  void onWindowClose() async {
+    bool isPreventClose = await windowManager.isPreventClose();
+    if (!isPreventClose) return;
+    await showDialog(
+      context: globalRouter.navigatorKey.currentContext!,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text('confirm_close_window'.i18n),
+        actions: [
+          TextButton(
+            child: Text('No'.i18n),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+          TextButton(
+            child: Text('Yes'.i18n),
+            onPressed: () async {
+              LanternFFI.exit();
+              await trayManager.destroy();
+              await windowManager.destroy();
+              exit(0);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/window/window_container.dart
+++ b/lib/features/window/window_container.dart
@@ -1,30 +1,7 @@
 import 'package:lantern/app.dart';
 import 'package:lantern/core/service/lantern_ffi_service.dart';
 import 'package:lantern/core/utils/common.dart';
-import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
-
-class WindowNotifier extends ChangeNotifier {
-  bool _isInitialized = false;
-  bool get isInitialized => _isInitialized;
-
-  Future<void> initialize() async {
-    await windowManager.ensureInitialized();
-    const double width = 360;
-    const double height = 712;
-
-    await windowManager.setSize(const Size(width, height));
-    _isInitialized = true;
-    notifyListeners();
-  }
-
-  Future<void> close() async {
-    await windowManager.hide();
-    if (Platform.isMacOS) {
-      await windowManager.setSkipTaskbar(true);
-    }
-  }
-}
 
 class WindowContainer extends StatefulWidget {
   const WindowContainer(this.child, {super.key});
@@ -38,19 +15,15 @@ class WindowContainer extends StatefulWidget {
 class _WindowContainerState extends State<WindowContainer> with WindowListener {
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: Provider.of<WindowNotifier>(context, listen: false).initialize(),
-      builder: (context, snapshot) {
-        return widget.child;
-      },
-    );
+    return widget.child;
   }
 
   @override
   void initState() {
     super.initState();
-    windowManager.addListener(this);
     if (isDesktop()) {
+      windowManager.addListener(this);
+      _initializeWindow();
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         await windowManager.setPreventClose(true);
         await windowManager.setResizable(false);
@@ -58,9 +31,16 @@ class _WindowContainerState extends State<WindowContainer> with WindowListener {
     }
   }
 
+  Future<void> _initializeWindow() async {
+    await windowManager.ensureInitialized();
+    await windowManager.setSize(const Size(360, 712));
+    await windowManager.show();
+    await windowManager.focus();
+  }
+
   @override
   void dispose() {
-    windowManager.removeListener(this);
+    if (isDesktop()) windowManager.removeListener(this);
     super.dispose();
   }
 
@@ -82,9 +62,11 @@ class _WindowContainerState extends State<WindowContainer> with WindowListener {
           TextButton(
             child: Text('Yes'.i18n),
             onPressed: () async {
+              await windowManager.hide();
+              if (Platform.isMacOS) {
+                await windowManager.setSkipTaskbar(true);
+              }
               LanternFFI.exit();
-              await trayManager.destroy();
-              await windowManager.destroy();
               exit(0);
             },
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,25 +34,6 @@ Future<void> main() async {
     // start backend services before setting up window
     LanternFFI.startDesktopService();
     await WebsocketSubscriber().connect();
-
-    await windowManager.ensureInitialized();
-    const double width = 360;
-    const double height = 712;
-
-    WindowOptions windowOptions = const WindowOptions(
-      size: ui.Size(width, height),
-      center: true,
-      backgroundColor: Colors.transparent,
-      skipTaskbar: false,
-      windowButtonVisibility: true,
-    );
-    await windowManager.setPreventClose(true);
-    //await windowManager.setResizable(false);
-    // make sure the window is initialized before rendering the UI
-    await windowManager.waitUntilReadyToShow(windowOptions, () async {
-      await windowManager.show();
-      await windowManager.focus();
-    });
   } else {
     await _initGoogleMobileAds();
     // Inject all the services


### PR DESCRIPTION
This PR includes updates to wrap the app in a window container. This encapsulates window management in a separate widget and makes it easier to maintain.