### PR TITLE
Implement TrayContainer and refactor LanternApp to use it

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:internet_connection_checker_plus/internet_connection_checker_plu
 import 'package:lantern/core/router/router.dart';
 import 'package:lantern/core/widgtes/custom_bottom_bar.dart';
 import 'package:lantern/features/messaging/messaging.dart';
+import 'package:lantern/features/tray/tray_container.dart';
 import 'package:lantern/features/vpn/vpn_notifier.dart';
 import 'package:lantern/features/window/window_container.dart';
 
@@ -114,6 +115,56 @@ class _LanternAppState extends State<LanternApp>
     }
   }
 
+  Widget _buildMaterialApp(BuildContext context, String lang) {
+    final currentLocal = View.of(context).platformDispatcher.locale;
+    final app = MaterialApp.router(
+      locale: currentLocale(lang),
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        useMaterial3: false,
+        fontFamily: _getLocaleBasedFont(currentLocal),
+        brightness: Brightness.light,
+        primarySwatch: Colors.grey,
+        appBarTheme: const AppBarTheme(
+          systemOverlayStyle: SystemUiOverlayStyle.dark,
+        ),
+        colorScheme: ColorScheme.fromSwatch().copyWith(secondary: Colors.black),
+      ),
+      title: 'app_name'.i18n,
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      routerConfig: globalRouter.config(
+        deepLinkBuilder: navigateToDeepLink,
+      ),
+      supportedLocales: const [
+        Locale('ar', 'EG'),
+        Locale('fr', 'FR'),
+        Locale('en', 'US'),
+        Locale('fa', 'IR'),
+        Locale('th', 'TH'),
+        Locale('ms', 'MY'),
+        Locale('ru', 'RU'),
+        Locale('ur', 'IN'),
+        Locale('zh', 'CN'),
+        Locale('zh', 'HK'),
+        Locale('es', 'ES'),
+        Locale('es', 'CU'),
+        Locale('tr', 'TR'),
+        Locale('vi', 'VN'),
+        Locale('my', 'MM'),
+      ],
+    );
+    if (isDesktop()) {
+      return WindowContainer(
+        TrayContainer(app),
+      );
+    }
+    return app;
+  }
+
   @override
   Widget build(BuildContext context) {
     final currentLocal = View.of(context).platformDispatcher.locale;
@@ -143,49 +194,7 @@ class _LanternAppState extends State<LanternApp>
             child: I18n(
               initialLocale: currentLocale(lang),
               child: ScaffoldMessenger(
-                child: WindowContainer(
-                  MaterialApp.router(
-                    locale: currentLocale(lang),
-                    debugShowCheckedModeBanner: false,
-                    theme: ThemeData(
-                      useMaterial3: false,
-                      fontFamily: _getLocaleBasedFont(currentLocal),
-                      brightness: Brightness.light,
-                      primarySwatch: Colors.grey,
-                      appBarTheme: const AppBarTheme(
-                        systemOverlayStyle: SystemUiOverlayStyle.dark,
-                      ),
-                      colorScheme: ColorScheme.fromSwatch()
-                          .copyWith(secondary: Colors.black),
-                    ),
-                    title: 'app_name'.i18n,
-                    localizationsDelegates: const [
-                      GlobalMaterialLocalizations.delegate,
-                      GlobalWidgetsLocalizations.delegate,
-                      GlobalCupertinoLocalizations.delegate,
-                    ],
-                    routerConfig: globalRouter.config(
-                      deepLinkBuilder: navigateToDeepLink,
-                    ),
-                    supportedLocales: const [
-                      Locale('ar', 'EG'),
-                      Locale('fr', 'FR'),
-                      Locale('en', 'US'),
-                      Locale('fa', 'IR'),
-                      Locale('th', 'TH'),
-                      Locale('ms', 'MY'),
-                      Locale('ru', 'RU'),
-                      Locale('ur', 'IN'),
-                      Locale('zh', 'CN'),
-                      Locale('zh', 'HK'),
-                      Locale('es', 'ES'),
-                      Locale('es', 'CU'),
-                      Locale('tr', 'TR'),
-                      Locale('vi', 'VN'),
-                      Locale('my', 'MM'),
-                    ],
-                  ),
-                ),
+                child: _buildMaterialApp(context, lang),
               ),
             ),
           );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -158,9 +158,7 @@ class _LanternAppState extends State<LanternApp>
       ],
     );
     if (isDesktop()) {
-      return WindowContainer(
-        TrayContainer(app),
-      );
+      return WindowContainer(TrayContainer(app));
     }
     return app;
   }

--- a/lib/features/tray/tray_container.dart
+++ b/lib/features/tray/tray_container.dart
@@ -1,0 +1,92 @@
+import 'package:lantern/core/utils/common.dart';
+import 'package:lantern/core/utils/common_desktop.dart';
+import 'package:lantern/features/vpn/vpn_notifier.dart';
+import 'package:tray_manager/tray_manager.dart';
+import 'package:window_manager/window_manager.dart';
+
+class TrayContainer extends StatefulWidget {
+  const TrayContainer(this.child, {super.key});
+
+  final Widget child;
+
+  @override
+  State<TrayContainer> createState() => _TrayContainerState();
+}
+
+class _TrayContainerState extends State<TrayContainer> with TrayListener {
+  @override
+  void initState() {
+    super.initState();
+    _initializeTray();
+  }
+
+  @override
+  void dispose() {
+    trayManager.removeListener(this);
+    super.dispose();
+  }
+
+  @override
+  Future<void> onTrayIconMouseDown() async {
+    windowManager.show();
+    trayManager.popUpContextMenu();
+  }
+
+  @override
+  void onTrayIconRightMouseDown() {
+    trayManager.popUpContextMenu();
+  }
+
+  /// system tray methods
+  Future<void> _initializeTray() async {
+    trayManager.addListener(this);
+    final vpnNotifier = context.read<VPNChangeNotifier>();
+    await _updateTrayMenu();
+    vpnNotifier.vpnStatus.addListener(_updateTrayMenu);
+  }
+
+  Future<void> _updateTrayMenu() async {
+    final vpnNotifier = context.read<VPNChangeNotifier>();
+    final isConnected = vpnNotifier.isConnected();
+    await trayManager.setIcon(getSystemTrayIconPath(isConnected));
+    Menu menu = Menu(
+      items: [
+        MenuItem(
+          key: 'status',
+          disabled: true,
+          label: isConnected ? 'status_on'.i18n : 'status_off'.i18n,
+        ),
+        MenuItem(
+          key: 'status',
+          label: isConnected ? 'disconnect'.i18n : 'connect'.i18n,
+          onClick: (item) => vpnNotifier.toggleConnection(),
+        ),
+        MenuItem.separator(),
+        MenuItem(
+            key: 'show_window',
+            label: 'show'.i18n,
+            onClick: (item) {
+              windowManager.focus();
+              windowManager.setSkipTaskbar(false);
+            }),
+        MenuItem.separator(),
+        MenuItem(
+          key: 'exit',
+          label: 'exit'.i18n,
+          onClick: (item) async {
+            LanternFFI.exit();
+            await trayManager.destroy();
+            await windowManager.destroy();
+            exit(0);
+          },
+        ),
+      ],
+    );
+    await trayManager.setContextMenu(menu);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}


### PR DESCRIPTION
This PR introduces a TrayContainer, similar to the recent changes to add a WindowContainer, and updates LanternApp to conditionally wrap both containers only on desktop.

It removes direct usage of tray_manager from the home widget, which was previously responsible for initializing the tray.