### PR TITLE
Fix fatal error: concurrent map access in setVals

### DIFF
--- a/desktop/settings/settings.go
+++ b/desktop/settings/settings.go
@@ -706,8 +706,8 @@ func (s *Settings) setVal(name SettingName, val interface{}) {
 }
 
 func (s *Settings) setVals(vals map[SettingName]interface{}) {
-	s.log.Debugf("Setting %v in %v", vals, s.m)
 	s.Lock()
+	s.log.Debugf("Setting %v in %v", vals, s.m)
 	for name, val := range vals {
 		s.m[name] = val
 	}


### PR DESCRIPTION
I noticed tests failing here https://github.com/getlantern/lantern-client/actions/runs/11689992926 due to the following:

```
  fatal error: concurrent map iteration and map write
 
  goroutine 215 [running]:
  reflect.mapiternext(0x4bac49?)
  	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/runtime/map.go:1397 +0x13
  reflect.(*MapIter).Next(0xc006c1f888?)
  	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/reflect/value.go:2005 +0x74
  internal/fmtsort.Sort({0x1867600?, 0xc000549140?, 0xc006c1fae0?})
  	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/internal/fmtsort/sort.go:62 +0x1d3
  fmt.(*pp).printValue(0xc006e0c000, {0x1867600?, 0xc000549140?, 0xd5?}, 0x76, 0x0)
  	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/fmt/print.go:816 +0x988
  fmt.(*pp).printArg(0xc006e0c000, {0x1867600, 0xc000549140}, 0x76)
  	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/fmt/print.go:759 +0x4bc
  fmt.(*pp).doPrintf(0xc006e0c000, {0x1b16c14, 0x10}, {0xc005d74160, 0x2, 0x2})
  	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/fmt/print.go:1075 +0x37e
  fmt.Sprintf({0x1b16c14, 0x10}, {0xc005d74160, 0x2, 0x2})
  	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/fmt/print.go:239 +0x53
  github.com/getlantern/golog.(*logger).printf(0xc0005494d0, 0xc00460edb0, 0x4, {0x1aff0ec, 0x5}, {0x1b16c14?, 0x1?}, {0xc005d74160, 0x2, 0x2})
  	/home/runner/go/pkg/mod/github.com/getlantern/golog@v0.0.0-20230503153817-8e72de7e0a65/golog.go:309 +0x4c
  github.com/getlantern/golog.(*logger).Debugf(0xc0005494d0, {0x1b16c14, 0x10}, {0xc005d74160, 0x2, 0x2})
  	/home/runner/go/pkg/mod/github.com/getlantern/golog@v0.0.0-20230503153817-8e72de7e0a65/golog.go:317 +0x86
  github.com/getlantern/lantern-client/desktop/settings.(*Settings).setVals(0xc000494310, 0xc004649ad0)
  	/home/runner/work/lantern-client/lantern-client/desktop/settings/settings.go:709 +0xb6
  github.com/getlantern/lantern-client/desktop/settings.(*Settings).SetUserIDAndToken(...)
  	/home/runner/work/lantern-client/lantern-client/desktop/settings/settings.go:605
 ```
 
This PR addresses the error by moving the logging statement inside the lock.