### PR TITLE
Update hit_proxy scipt to work with new config format.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/getlantern/eventual v1.0.0
 	github.com/getlantern/eventual/v2 v2.0.2
 	github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c
-	github.com/getlantern/flashlight/v7 v7.6.147
+	github.com/getlantern/flashlight/v7 v7.6.148
 	github.com/getlantern/fronted v0.0.0-20241120203013-eedcd71609d2
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65
 	github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/getlantern/fdcount v0.0.0-20210503151800-5decd65b3731/go.mod h1:XZwE+
 github.com/getlantern/filepersist v0.0.0-20160317154340-c5f0cd24e799/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c h1:mcz27xtAkb1OuOLBct/uFfL1p3XxAIcFct82GbT+UZM=
 github.com/getlantern/filepersist v0.0.0-20210901195658-ed29a1cb0b7c/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
-github.com/getlantern/flashlight/v7 v7.6.147 h1:sF5wftnezW3kg3vn2dLpNDTHc25BhrwnHJox2zZChHo=
-github.com/getlantern/flashlight/v7 v7.6.147/go.mod h1:sLQXxC8MW4gqHXFjINLxbbz1GOPEf6Hwvs30gdVsAk8=
+github.com/getlantern/flashlight/v7 v7.6.148 h1:d55hhqjiVpEtzs70N93sBzCgHEXZ3EFfGdEirlv7Ev4=
+github.com/getlantern/flashlight/v7 v7.6.148/go.mod h1:sLQXxC8MW4gqHXFjINLxbbz1GOPEf6Hwvs30gdVsAk8=
 github.com/getlantern/framed v0.0.0-20190601192238-ceb6431eeede h1:yrU6Px3ZkvCsDLPryPGi6FN+2iqFPq+JeCb7EFoDBhw=
 github.com/getlantern/framed v0.0.0-20190601192238-ceb6431eeede/go.mod h1:nhnoiS6DE6zfe+BaCMU4YI01UpsuiXnDqM5S8jxHuuI=
 github.com/getlantern/fronted v0.0.0-20241120203013-eedcd71609d2 h1:h3TZ7ye/1fqOLqfwTho4iRSEQqTMKVJIsOF+5XNyhus=

--- a/hit_proxy.bash
+++ b/hit_proxy.bash
@@ -8,13 +8,22 @@ set -ef -o pipefail
 
 PROXY="${1:?please specify the proxy IP}"
 TMPDIR="${TMP:-/tmp}/hit_lc_proxy/$PROXY"
-OUTFILE="$TMPDIR/proxies.yaml"
+OUTFILE="$TMPDIR/user.conf"
 
 rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR"
 
 echo "Generating config for ${PROXY} in ${OUTFILE}..."
-$LANTERN_CLOUD/bin/lc route dump-config --legacy "$PROXY" > "$OUTFILE"
+CONFIG=$($LANTERN_CLOUD/bin/lc route dump-config $PROXY)
+OUTPUT="{\"proxy\":{\"proxies\":[${CONFIG}]}}"
+
+# check if jq is installed and reformat the output
+if command -v jq &> /dev/null
+then
+	echo $OUTPUT | jq . > $OUTFILE
+else
+	echo $OUTPUT > $OUTFILE
+fi
 
 make darwin ffigen
 LANTERN_CONFIGDIR=$TMPDIR \


### PR DESCRIPTION
This PR updates the config filename and wraps the `dump-config` output with the keys flashlight expects. There might be a better way to handle this instead of hard-coding it. 