### PR TITLE
Fix user create api on android.

### DIFF
--- a/desktop/app/app.go
+++ b/desktop/app/app.go
@@ -571,9 +571,9 @@ func (app *App) fetchOrCreateUser(ctx context.Context) {
 	}
 	if userID := ss.GetUserID(); userID == 0 {
 		ss.SetUserFirstVisit(true)
-		app.proClient.RetryCreateUser(ctx, ss, 5*time.Minute)
+		app.proClient.RetryCreateUser(ctx, app, 5*time.Minute)
 	} else {
-		app.proClient.UpdateUserData(ctx, ss)
+		app.proClient.UpdateUserData(ctx, app)
 	}
 }
 
@@ -627,6 +627,7 @@ func (app *App) GetPaymentMethods(ctx context.Context) ([]protos.PaymentMethod, 
 }
 
 // FetchPaymentMethods returns the plans and payment plans available to a user
+// Updates cache with the fetched data
 func (app *App) FetchPaymentMethods(ctx context.Context) (*proclient.PaymentMethodsResponse, error) {
 	resp, err := app.proClient.PaymentMethodsV4(context.Background())
 	if err != nil {
@@ -727,4 +728,38 @@ func (app *App) ProClient() pro.ProClient {
 	app.mu.RLock()
 	defer app.mu.RUnlock()
 	return app.proClient
+}
+
+// Client session methods
+func (app *App) FetchUserData() error {
+	go app.FetchPaymentMethods(context.Background())
+	return nil
+}
+
+func (app *App) GetDeviceID() (string, error) {
+	return app.Settings().GetDeviceID(), nil
+}
+
+func (app *App) GetUserFirstVisit() (bool, error) {
+	return app.Settings().GetUserFirstVisit(), nil
+}
+
+func (app *App) SetUserIDAndToken(id int64, token string) error {
+	app.Settings().SetUserIDAndToken(id, token)
+	return nil
+}
+
+func (app *App) SetProUser(pro bool) error {
+	app.Settings().SetProUser(pro)
+	return nil
+}
+
+func (app *App) SetReferralCode(referral string) error {
+	app.Settings().SetReferralCode(referral)
+	return nil
+}
+
+func (app *App) SetExpiration(exp int64) error {
+	app.Settings().SetExpiration(exp)
+	return nil
 }

--- a/desktop/lib.go
+++ b/desktop/lib.go
@@ -150,7 +150,7 @@ func setProxyAll(value *C.char) {
 func hasPlanUpdatedOrBuy() *C.char {
 	ctx := context.Background()
 	proClient := a.ProClient()
-	go proClient.PollUserData(ctx, a.Settings(), 10*time.Minute, proClient)
+	go proClient.PollUserData(ctx, a, 10*time.Minute, proClient)
 	//Get the cached user data
 	log.Debugf("DEBUG: Checking if user has updated plan or bought new plan")
 	cacheUserData, isOldFound := cachedUserData()

--- a/desktop/settings/settings.go
+++ b/desktop/settings/settings.go
@@ -620,6 +620,11 @@ func (s *Settings) GetToken() string {
 	return s.getString(SNUserToken)
 }
 
+// GetToken returns the user token
+func (s *Settings) FetchUserData() error {
+	return nil
+}
+
 // GetMigratedDeviceIDForUserID returns the user ID (if any) for which the current device's ID has been migrated from the old style to the new style
 func (s *Settings) GetMigratedDeviceIDForUserID() int64 {
 	return s.getInt64(SNMigratedDeviceIDForUserID)

--- a/internalsdk/android.go
+++ b/internalsdk/android.go
@@ -710,11 +710,11 @@ func geoLookup(session PanickingSession) {
 
 func afterStart(wrappedSession Session, session PanickingSession) {
 
-	if session.GetUserID() == 0 {
-		ctx := context.Background()
-		proClient := createProClient(wrappedSession, "android")
-		go proClient.RetryCreateUser(ctx, session, 10*time.Minute)
-	}
+	// if session.GetUserID() == 0 {
+	// 	ctx := context.Background()
+	// 	proClient := createProClient(wrappedSession, "android")
+	// 	go proClient.RetryCreateUser(ctx, session, 10*time.Minute)
+	// }
 
 	bandwidthUpdates(session)
 


### PR DESCRIPTION
This PR fixes the issue while calling user-create API on Android multiple times, Also sometimes `/plans` get called before the user creates still on going so other API calls fail because due user is not found.