### PR TITLE
Start config service sooner and don't copy mutex

### DIFF
--- a/desktop/app/config.go
+++ b/desktop/app/config.go
@@ -61,7 +61,7 @@ func (s *configService) StartService(channel ws.UIChannel) (err error) {
 	return err
 }
 
-func (s *configService) sendConfigOptions(cfg ConfigOptions) {
+func (s *configService) sendConfigOptions(cfg *ConfigOptions) {
 	b, _ := json.Marshal(&cfg)
 	log.Debugf("Sending config options to client %s", string(b))
 	s.service.Out <- cfg
@@ -90,7 +90,7 @@ func (app *App) sendConfigOptions() {
 	log.Debugf("DEBUG: Devices: %s", string(devices))
 	log.Debugf("Expiration date: %s", app.settings.GetExpirationDate())
 
-	app.configService.sendConfigOptions(ConfigOptions{
+	app.configService.sendConfigOptions(&ConfigOptions{
 		DevelopmentMode:      common.IsDevEnvironment(),
 		AppVersion:           common.ApplicationVersion,
 		ReplicaAddr:          "",


### PR DESCRIPTION
The current code was crashing for me when the config service was asked to process a config before it had started. There was also a warning about copying a mutex in a struct arg.