### PR TITLE
Update Android build to support Go 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,11 @@ auto-updates: require-version require-s3cmd require-gh-token require-ruby
 
 release: require-version require-s3cmd require-wget require-lantern-binaries require-release-track release-prod copy-beta-installers-to-mirrors invalidate-getlantern-dot-org upload-aab-to-play
 
+# github.com/wlynxg/anet relies on //go:linkname so we explicitly pass the -checklinkname=0
+# linker flag here to be able to build Android with Go 1.23
+# See https://github.com/wlynxg/anet#how-to-build-with-go-1230-or-later
+# and https://github.com/golang/go/pull/61089
+$(ANDROID_LIB): export EXTRA_LDFLAGS += -checklinkname=0
 $(ANDROID_LIB): $(GO_SOURCES)
 	go env -w 'GOPRIVATE=github.com/getlantern/*' && \
 	go install golang.org/x/mobile/cmd/gomobile && \
@@ -352,7 +357,7 @@ $(ANDROID_LIB): $(GO_SOURCES)
 	    -target=$(ANDROID_ARCH_GOMOBILE) \
 		-tags='headless lantern' -o=$(ANDROID_LIB) \
 		-androidapi=23 \
-		-ldflags="$(LDFLAGS) $(EXTRA_LDFLAGS)" \
+		-ldflags="-s -w $(LDFLAGS) $(EXTRA_LDFLAGS)" \
 		$(GOMOBILE_EXTRA_BUILD_FLAGS) \
 		github.com/getlantern/lantern-client/internalsdk github.com/getlantern/pathdb/testsupport github.com/getlantern/pathdb/minisql
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/getlantern/notifier v0.0.0-20240830181717-11f4c6c3fa95
 	github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175
-	github.com/getlantern/pathdb v0.0.0-20241211161442-69cb05914a59
+	github.com/getlantern/pathdb v0.0.0-20241211163908-4506f9acbd84
 	github.com/getlantern/profiling v0.0.0-20160317154340-2a15afbadcff
 	github.com/getlantern/replica v0.14.5-0.20240909174421-21691d4b40f8
 	github.com/getlantern/safechannels v0.0.0-20201218194342-b4e5383e9627

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/getlantern/lantern-client
 
-go 1.22.4
+go 1.23.1
 
-toolchain go1.22.8
+toolchain go1.23.4
 
 // replace github.com/getlantern/flashlight/v7 => ../flashlight
 
@@ -53,7 +53,7 @@ require (
 	github.com/getlantern/notifier v0.0.0-20240830181717-11f4c6c3fa95
 	github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175
-	github.com/getlantern/pathdb v0.0.0-20231026090702-54ee1ddd99eb
+	github.com/getlantern/pathdb v0.0.0-20241211161442-69cb05914a59
 	github.com/getlantern/profiling v0.0.0-20160317154340-2a15afbadcff
 	github.com/getlantern/replica v0.14.5-0.20240909174421-21691d4b40f8
 	github.com/getlantern/safechannels v0.0.0-20201218194342-b4e5383e9627

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,8 @@ github.com/getlantern/packetforward v0.0.0-20201001150407-c68a447b0360 h1:pijUoo
 github.com/getlantern/packetforward v0.0.0-20201001150407-c68a447b0360/go.mod h1:nsJPNYUSY96xB+p7uiDW8O4uiKea+KjeUdS5d6tf9IU=
 github.com/getlantern/pathdb v0.0.0-20241211161442-69cb05914a59 h1:uG5tdeDN40wyEX21BxPW4js4UeOwvr66Tf4c2QX+Q8k=
 github.com/getlantern/pathdb v0.0.0-20241211161442-69cb05914a59/go.mod h1:6ylfyLeaekF7nVRbNSho3cMHRLVlpAiC0AMoqOowCzA=
+github.com/getlantern/pathdb v0.0.0-20241211163908-4506f9acbd84 h1:GAe56HacdtucsvV+mN+A7kJCr8upbu/5eKMKCszKCbc=
+github.com/getlantern/pathdb v0.0.0-20241211163908-4506f9acbd84/go.mod h1:6ylfyLeaekF7nVRbNSho3cMHRLVlpAiC0AMoqOowCzA=
 github.com/getlantern/preconn v1.0.0 h1:DsY3l/y/BJUj86WyaxXylbJnCC9QbKcc3D6js6rFL60=
 github.com/getlantern/preconn v1.0.0/go.mod h1:i/AnXvx715Fq7HgZLlmQlw3sGfEkku8BQT5hLHMK4+k=
 github.com/getlantern/probe v0.0.0-20191107230642-ed284e08029a/go.mod h1:EPE0nd9YNS2FTIz+2EOkqojCuqaQlJ+fTiLPklsqe/E=

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/packetforward v0.0.0-20201001150407-c68a447b0360 h1:pijUoofaQcAM/8zbDzZM2LQ90kGVbKfnSAkFnQwLZZU=
 github.com/getlantern/packetforward v0.0.0-20201001150407-c68a447b0360/go.mod h1:nsJPNYUSY96xB+p7uiDW8O4uiKea+KjeUdS5d6tf9IU=
-github.com/getlantern/pathdb v0.0.0-20231026090702-54ee1ddd99eb h1:rbkflUPjr83ON7c+4LqU2Y/rJzv9P/fmocXDLLm0hWQ=
-github.com/getlantern/pathdb v0.0.0-20231026090702-54ee1ddd99eb/go.mod h1:SFQy+f58IbLpnbq2nVqlq7ccwaUiO7ablKv631WVIuc=
+github.com/getlantern/pathdb v0.0.0-20241211161442-69cb05914a59 h1:uG5tdeDN40wyEX21BxPW4js4UeOwvr66Tf4c2QX+Q8k=
+github.com/getlantern/pathdb v0.0.0-20241211161442-69cb05914a59/go.mod h1:6ylfyLeaekF7nVRbNSho3cMHRLVlpAiC0AMoqOowCzA=
 github.com/getlantern/preconn v1.0.0 h1:DsY3l/y/BJUj86WyaxXylbJnCC9QbKcc3D6js6rFL60=
 github.com/getlantern/preconn v1.0.0/go.mod h1:i/AnXvx715Fq7HgZLlmQlw3sGfEkku8BQT5hLHMK4+k=
 github.com/getlantern/probe v0.0.0-20191107230642-ed284e08029a/go.mod h1:EPE0nd9YNS2FTIz+2EOkqojCuqaQlJ+fTiLPklsqe/E=
@@ -1244,6 +1244,8 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
+google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This resolves an issue building Android with Go 1.23.0 and above:

```
go env -w 'GOPRIVATE=github.com/getlantern/*' && \
	go install golang.org/x/mobile/cmd/gomobile && \
	gomobile init && \
	gomobile bind \
	    -target=android \
		-tags='headless lantern' -o=liblantern-all.aar \
		-androidapi=23 \
		-ldflags="-X github.com/getlantern/lantern-client/internalsdk/common.RevisionDate=20241206.175008 -X github.com/getlantern/lantern-client/internalsdk/common.BuildDate=20241209.051925  -X github.com/getlantern/lantern-client/internalsdk/common.ApplicationVersion=9999.99.99" \
		 \
		github.com/getlantern/lantern-client/internalsdk github.com/getlantern/pathdb/testsupport github.com/getlantern/pathdb/minisql
gomobile: go build -tags headless,lantern -ldflags -X github.com/getlantern/lantern-client/internalsdk/common.RevisionDate=20241206.175008 -X github.com/getlantern/lantern-client/internalsdk/common.BuildDate=20241209.051925  -X github.com/getlantern/lantern-client/internalsdk/common.ApplicationVersion=9999.99.99 -buildmode=c-shared -o=/var/folders/j5/yrnkkcxx6wlcr7h2f574qfjc0000gn/T/gomobile-work-3367332437/android/src/main/jniLibs/armeabi-v7a/libgojni.so ./gobind failed: exit status 1
# gobind/gobind
link: github.com/wlynxg/anet: invalid reference to net.zoneCache
```

The anet library relies on //go:linkname so we explicitly pass the -checklinkname=0 linker flag here to be able to build Android with Go 1.23 (which deprecated use of it).

See https://github.com/wlynxg/anet/blob/main/README.md#how-to-build-with-go-1230-or-later

