### PR TITLE
Set Fronted on IOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,8 +444,6 @@ set-version:
 	NEXT_BUILD=$$(($$CURRENT_BUILD + 1)); \
 	/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $$NEXT_BUILD" $(INFO_PLIST)
 
-ios: macos build-framework ffigen
-
 ios-release: set-version guard-SENTRY_AUTH_TOKEN guard-SENTRY_ORG guard-SENTRY_PROJECT_IOS pubget
 	@echo "Flutter Clean"
 	flutter clean

--- a/internalsdk/session_model.go
+++ b/internalsdk/session_model.go
@@ -163,11 +163,25 @@ func NewSessionModel(mdb minisql.DB, opts *SessionModelOpts) (*SessionModel, err
 	token, _ := m.GetToken()
 	lang, _ := m.Locale()
 
-	m.proClient = createProClient(m, opts.Platform)
-
 	authUrl := common.DFBaseUrl
 	if opts.Platform == "ios" {
 		authUrl = common.APIBaseUrl
+		m.proClient = pro.NewIOSClient(fmt.Sprintf("https://%s", common.ProAPIHost), func() common.UserConfig {
+			internalHeaders := map[string]string{
+				common.PlatformHeader:   opts.Platform,
+				common.AppVersionHeader: common.ApplicationVersion,
+			}
+			return common.NewUserConfig(
+				common.DefaultAppName,
+				deviceID,
+				userID,
+				token,
+				internalHeaders,
+				lang,
+			)
+		}, opts.ConfigPath)
+	} else {
+		m.proClient = createProClient(m, opts.Platform)
 	}
 	m.authClient = auth.NewClient(fmt.Sprintf("https://%s", authUrl), func() common.UserConfig {
 		internalHeaders := map[string]string{


### PR DESCRIPTION
The latest fronted  code crashed on IOS, the Reason being we were not setting fronted, on Android it's set by flashlight, This Pr should fix that issue

fronted.go

```
// Use a wrapper for fronted.NewDirect to avoid blocking
// `dualFetcher.RoundTrip` when fronted is not yet available, especially when
// the application is starting up
func (f frontedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
	if f.opName != "" {
		op := ops.Begin(f.opName)
		defer op.End()
	}
	return fronter.RoundTrip(req)
}
```