### PR TITLE
Upload debug symbols

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
         if: matrix.platform == 'macos'
         with:
           node-version: 18
-    
+
       - name: Install macOS dependencies
         if: matrix.platform == 'macos'
         run: |
@@ -289,12 +289,15 @@ jobs:
 
       - name: Build Flutter app (Android)
         if: matrix.platform == 'android'
-        run: make ${{ matrix.platform }}-${{ matrix.target }}-release
         env:
           VERSION: ${{ env.version }}
+        run: |
+          make ${{ matrix.platform }}-${{ matrix.target }}-release
+          @echo "Generating debug symbols"
+          make debug-symbols
 
       - name: Build Flutter app
-        if: matrix.platform != 'windows' && matrix.platform != 'android' 
+        if: matrix.platform != 'windows' && matrix.platform != 'android'
         run: make ${{ matrix.platform }}-release
         env:
           VERSION: ${{ env.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,9 @@ jobs:
           packageName: org.getlantern.lantern
           releaseFiles: lantern-installer.aab
           track: beta
+          debugSymbols: ${{ github.workspace }}/build/outputs/debug-symbols/debug-symbols.zip
+          mappingFile: ${{ github.workspace }}/build/app/outputs/mapping/prodPlay/mapping.txt
+
 
       - name: Upload Android App bundle to Play Store (production)
         if: needs.set-version.outputs.prefix == 'lantern-installer' && (needs.determine-platform.outputs.platform == 'android' || needs.determine-platform.outputs.platform == 'all')
@@ -172,6 +175,8 @@ jobs:
           packageName: org.getlantern.lantern
           releaseFiles: lantern-installer.aab
           track: production
+          debugSymbols: ${{ github.workspace }}/build/outputs/debug-symbols/debug-symbols.zip
+          mappingFile: ${{ github.workspace }}/build/app/outputs/mapping/prodPlay/mapping.txt
 
       - name: Grant private modules access
         run: git config --global url."https://${{ secrets.CI_PRIVATE_REPOS_GH_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"

--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,11 @@ $(MOBILE_BUNDLE): $(MOBILE_SOURCES) $(GO_SOURCES) $(MOBILE_ANDROID_LIB) require-
 
 android-debug: $(MOBILE_DEBUG_APK)
 
+
+debug-symbols:
+	@echo "Generating debug symbols for Android..."
+	cd android && ./gradlew zipDebugSymbols
+
 set-version:
 	@echo "Setting the CFBundleShortVersionString to $(VERSION)"
 	@cd ios && agvtool new-marketing-version $(VERSION)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -195,6 +195,25 @@ android {
     namespace 'org.getlantern.lantern'
 }
 
+tasks.register('zipDebugSymbols') {
+    description "Generates a ZIP file containing debug symbols for the app"
+    doLast {
+        def flutterRootDir = rootDir.parentFile
+        def debugSymbolsDir = file("${flutterRootDir}/build/app/intermediates/merged_native_libs/prodPlay/mergeProdPlayNativeLibs/out/lib")
+        def outputDir = file("${flutterRootDir}/build/outputs/debug-symbols")
+        outputDir.mkdirs()
+        copy {
+            from debugSymbolsDir
+            into outputDir
+        }
+        ant.zip(destfile: "${outputDir}/debug-symbols.zip") {
+            fileset(dir: debugSymbolsDir)
+        }
+        println "Debug symbols ZIP created at: ${outputDir}/debug-symbols.zip"
+    }
+}
+
+
 def androidArch() {
     def value = project.getProperties().get("androidArch")
     if (value == null || !value?.trim()) {


### PR DESCRIPTION
This PR adds support for uploading debug symbols to the Play Store, which will help us deobfuscate logs.