### PR TITLE
Disable uploading build to Testflight for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,14 +175,14 @@ jobs:
         with:
           name: Lantern.ipa
 
-      - name: Upload Lantern to TestFlight
-        uses: apple-actions/upload-testflight-build@v1
-        if: (needs.set-version.outputs.prefix == 'lantern-installer-preview'|| needs.set-version.outputs.prefix == 'lantern-installer') && (needs.determine-platform.outputs.platform == 'ios' || needs.determine-platform.outputs.platform == 'all')
-        with:
-          app-path: Lantern.ipa
-          issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
-          api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
-          api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+      # - name: Upload Lantern to TestFlight
+      #   uses: apple-actions/upload-testflight-build@v1
+      #   if: (needs.set-version.outputs.prefix == 'lantern-installer-preview'|| needs.set-version.outputs.prefix == 'lantern-installer') && (needs.determine-platform.outputs.platform == 'ios' || needs.determine-platform.outputs.platform == 'all')
+      #   with:
+      #     app-path: Lantern.ipa
+      #     issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+      #     api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
+      #     api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
 
       - name: Upload Android App bundle to Play Store (beta)
         if: needs.set-version.outputs.prefix == 'lantern-installer-preview' && (needs.determine-platform.outputs.platform == 'android' || needs.determine-platform.outputs.platform == 'all')


### PR DESCRIPTION
I'm unable to push a new 8.0.0 release because of the following issue uploading the iOS build to Testflight: https://github.com/getlantern/lantern-client/actions/runs/12958781057/job/36150481991#step:11:16

> This bundle is invalid. The value for key CFBundleShortVersionString [8.0.0] in the Info.plist file must contain a higher version than that of the previously approved version [8.0.5]

I'm not sure how we fix this @jigar-f? I'm just going to disable uploading the iOS build to Testflight for now to get a release out. FYI @Derekf5 

