### PR TITLE
Android prod updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
       SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
       SENTRY_ORG: getlantern
       SENTRY_PROJECT_IOS: lantern-ios
+      SENTRY_PROJECT_ANDROID: android
     strategy:
       matrix:
         include:

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ FORCE_PLAY_VERSION ?= false
 DEBUG_VERSION ?= $(GIT_REVISION)
 
 DWARF_DSYM_FOLDER_PATH=$(shell pwd)/build/ios/archive/Runner.xcarchive/dSYMs/
+ANDROID_DEBUG_SYMBOL=/build/app/intermediates/merged_native_libs/prodPlay/mergeProdPlayNativeLibs/out/lib
 INFO_PLIST := ios/Runner/Info.plist
 ENTITLEMENTS := macos/Runner/Release.entitlements
 
@@ -402,7 +403,7 @@ $(MOBILE_DEBUG_APK): $(MOBILE_SOURCES) $(GO_SOURCES)
 	make do-android-debug && \
 	cp $(MOBILE_ANDROID_DEBUG) $(MOBILE_DEBUG_APK)
 
-$(MOBILE_RELEASE_APK): $(MOBILE_SOURCES) $(GO_SOURCES) $(MOBILE_ANDROID_LIB) ffigen require-sentry require-sentry-auth-token
+$(MOBILE_RELEASE_APK): $(MOBILE_SOURCES) $(GO_SOURCES) $(MOBILE_ANDROID_LIB) ffigen require-sentry guard-SENTRY_PROJECT_ANDROID guard-SENTRY_AUTH_TOKEN
 	echo $(MOBILE_ANDROID_LIB) && \
 	mkdir -p ~/.gradle && \
 	ln -fs $(MOBILE_DIR)/gradle.properties . && \
@@ -416,7 +417,7 @@ $(MOBILE_RELEASE_APK): $(MOBILE_SOURCES) $(GO_SOURCES) $(MOBILE_ANDROID_LIB) ffi
 	-PandroidArchJava="$(ANDROID_ARCH_JAVA)" -PproServerUrl=$(PRO_SERVER_URL) -PpaymentProvider=$(PAYMENT_PROVIDER) \
 	-Pcountry=$(COUNTRY) -PplayVersion=$(FORCE_PLAY_VERSION) -PuseStaging=$(STAGING) -PstickyConfig=$(STICKY_CONFIG) \
 	-PversionCode=$(VERSION_CODE) -PdevelopmentMode=$(DEVELOPMENT_MODE) -b $(MOBILE_DIR)/app/build.gradle assembleProdSideload && \
-	sentry-cli upload-dif --wait -o getlantern -p android build/app/intermediates/merged_native_libs/prodSideload/out/lib && \
+	sentry-cli --auth-token $(SENTRY_AUTH_TOKEN) upload-dif --include-sources --org $(SENTRY_ORG) --project $(SENTRY_PROJECT_ANDROID) $(ANDROID_DEBUG_SYMBOL)
 	cp $(MOBILE_ANDROID_RELEASE) $(MOBILE_RELEASE_APK) && \
 	cat $(MOBILE_RELEASE_APK) | bzip2 > lantern_update_android_arm.bz2
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,6 @@ plugins {
     id 'org.jlleitschuh.gradle.ktlint'
     id 'kotlin-parcelize'
     id 'com.google.protobuf'
-    id "io.sentry.android.gradle" version "4.13.0"
 }
 
 android {
@@ -378,51 +377,3 @@ dependencies {
     testImplementation "io.mockk:mockk:1.13.5"
 }
 
-
-sentry {
-
-    // Disables or enables debug log output, e.g. for for sentry-cli.
-    // Default is disabled.
-    debug = false
-
-    // The slug of the Sentry organization to use for uploading proguard mappings/source contexts.
-    org = "getlantern"
-
-    // The slug of the Sentry project to use for uploading proguard mappings/source contexts.
-    projectName = "android"
-
-    // The authentication token to use for uploading proguard mappings/source contexts.
-    // WARNING: Do not expose this token in your build.gradle files, but rather set an environment
-    // variable and read it into this property.
-    authToken = System.getenv("SENTRY_AUTH_TOKEN")
-
-    // The url of your Sentry instance. If you're using SAAS (not self hosting) you do not have to
-    // set this. If you are self hosting you can set your URL here
-    url = null
-
-    // Disables or enables the handling of Proguard mapping for Sentry.
-    // If enabled the plugin will generate a UUID and will take care of
-    // uploading the mapping to Sentry. If disabled, all the logic
-    // related to proguard mapping will be excluded.
-    // Default is enabled.
-    includeProguardMapping = true
-
-
-    // Whether the plugin should attempt to auto-upload the mapping file to Sentry or not.
-    // If disabled the plugin will run a dry-run and just generate a UUID.
-    // The mapping file has to be uploaded manually via sentry-cli in this case.
-    // Default is enabled.
-    autoUploadProguardMapping = true
-
-    // Disables or enables the automatic configuration of Native Symbols
-    // for Sentry. This executes sentry-cli automatically so
-    // you don't need to do it manually.
-    // Default is disabled.
-    uploadNativeSymbols = false
-
-    // Does or doesn't include the source code of native code for Sentry.
-    // This executes sentry-cli with the --include-sources param. automatically so
-    // you don't need to do it manually.
-    // Default is disabled.
-    includeNativeSources = false
-}


### PR DESCRIPTION
- Get Rid of the sentry gradle plugin, It Seems like it was not uploading the debug symbol in sentry, it was just uploading mapping files.
- Remove panics from internal sdk.