### PR TITLE
use macos-15 runner instead of latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             platform: macos
           - os: windows-latest
             platform: windows


### PR DESCRIPTION
I meant to revert this change before merging https://github.com/getlantern/lantern-client/pull/1332