### PR TITLE
remove flutter version input to build.yaml workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,6 @@ on:
       xcode_version:
         type: string
         required: true
-      flutter_version:
-        type: string
-        required: true
       macos_version:
         type: string
         required: true


### PR DESCRIPTION
This pull request modifies the `.github/workflows/build.yml` file by removing the `flutter_version` input parameter from the workflow configuration. Per previous [PR](https://github.com/getlantern/lantern-client/pull/1343), `build.yml` is now using the `pubspec.yml` file to determine version.